### PR TITLE
gather status codes at redis backend

### DIFF
--- a/uperf-wrapper/Dockerfile
+++ b/uperf-wrapper/Dockerfile
@@ -4,7 +4,7 @@ RUN dnf copr enable ndokos/pbench -y
 RUN dnf install -y --nodocs git python3-pip python3-numpy python3-requests python3-numpy pbench-uperf
 COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream
-RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2" pyyaml
+RUN pip3 install --upgrade-strategy=only-if-needed "elasticsearch>=6.0.0,<=7.0.2" pyyaml redis
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/

--- a/uperf-wrapper/redis_utils.py
+++ b/uperf-wrapper/redis_utils.py
@@ -1,0 +1,12 @@
+#!/usr/bin/python
+
+import redis
+
+class RedisUtils:
+    def __init__(self, redis_host, redis_port):
+        self.redis_host = redis_host
+        self.redis_port = redis_port
+        self.redis_cache = redis.Redis(host=self.redis_host, port=self.redis_port)
+
+    def set_code(self, test_name, test_args, test_status_code,):
+        self.redis_cache.hset(test_name, test_args, test_status_code)


### PR DESCRIPTION
`Depends-On: 289`
@jtaleric @aakarshg 
a simpler execution of PR #136. Here the `hash/key/value` looks like `uperf-test/status/0|1|2` with 
```
0: Completed
1: Failed
2: Running
```
This PR is to be tested with https://github.com/cloud-bulldozer/ripsaw/pull/289 to get the continue/abort functionality

This commit also adds the ability to echo the test which failed for better readability
`UPerf failed to execute with args uperf-stream-tcp-16384-8, trying one more time..`