### PR TITLE
Fs drift cleanups

### DIFF
--- a/fs_drift_wrapper/trigger_fs_drift.py
+++ b/fs_drift_wrapper/trigger_fs_drift.py
@@ -173,7 +173,7 @@ class _trigger_fs_drift:
                         if rate_obj == None:
                             self.logger.info(
                                 'no workload rate info for thread %s in interval starting at %s' %
-                                (thread_id, json_obj['elapsed_time']))
+                                (thread_id, str(json_obj)))
                             continue
                         previous_obj = json_obj
 

--- a/fs_drift_wrapper/trigger_fs_drift.py
+++ b/fs_drift_wrapper/trigger_fs_drift.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 import subprocess
 import re
 import time
@@ -66,6 +67,7 @@ class _trigger_fs_drift:
         finally:
             fsd_output_lines = [ l.strip().decode('utf-8') for l in fsd_output.splitlines() ]
             for l in fsd_output_lines: print(l)
+            sys.stdout.flush()
         for l in fsd_output_lines:
             if l.__contains__('report interval'):
                 sampling_interval = int(l.split()[-1])

--- a/fs_drift_wrapper/trigger_fs_drift.py
+++ b/fs_drift_wrapper/trigger_fs_drift.py
@@ -62,6 +62,7 @@ class _trigger_fs_drift:
             fsd_output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
             self.logger.exception(e)
+            fsd_output = e.output
             raise FsDriftWrapperException(
                 'fs-drift.py non-zero process return code %d' % e.returncode)
         finally:

--- a/fs_drift_wrapper/trigger_fs_drift.py
+++ b/fs_drift_wrapper/trigger_fs_drift.py
@@ -162,6 +162,11 @@ class _trigger_fs_drift:
                         json_start = index
                         json_obj = json.loads(json_str)
                         rate_obj = self.compute_rates(json_obj, previous_obj)
+                        if rate_obj == None:
+                            self.logger.info(
+                                'no response time data for thread %s in interval starting at %s' %
+                                (thread_id, json_obj['elapsed_time']))
+                            continue
                         previous_obj = json_obj
 
                         # timestamp this sample
@@ -194,7 +199,11 @@ class _trigger_fs_drift:
         else:
             previous_time_since_test_start = 0
         delta_time = time_since_test_start - previous_time_since_test_start
-        assert delta_time > 0.5
+        if delta_time < 0.1:
+            self.logger.info(
+                'current time %f not greater than previous time %f' %
+                (time_since_test_start, previous_time_since_test_start))
+            return None
         rate_dict = {}
         for k in current_sample.keys():
             if k != 'elapsed-time':


### PR DESCRIPTION
these changes allowed me to run fs-drift for an hour and a half and get data even in the presence of intervals where some threads were hung due to MDS crashes.