### PR TITLE
put delay after cache dropping to let system recover from it

### DIFF
--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -20,15 +20,12 @@ if [[ $ghprbPullLongDescription = *"Depends-On:"* ]]; then
   cd ..
 fi
 
-pushd ripsaw
-update_operator_image
-popd
-
 cd ripsaw
 sed -i "s/ES_SERVER/$ES_SERVER/g" tests/test_crs/*
 sed -i "s/ES_PORT/$ES_PORT/g" tests/test_crs/*
 sed -i "s/my-ripsaw/my-ripsaw-$UUID/g" `grep -Rl my-ripsaw`
 sed -i "s/sql-server/sql-server-$UUID/g" tests/mssql.yaml tests/test_crs/valid_hammerdb.yaml tests/test_hammerdb.sh
+update_operator_image
 cd ..
 
 sed -i "s/my-ripsaw/my-ripsaw-$UUID/g" ci/common.sh

--- a/snafu/utils/request_cache_drop.py
+++ b/snafu/utils/request_cache_drop.py
@@ -83,9 +83,9 @@ def drop_cache():
                 logger.error('HTTP code %d: %s' % (rsp.status, rsp.reason))
                 raise RunSnafuCacheDropException('kernel cache drop %s:%d' %
                                                  (ip, dropKernelCachePort))
-    # give kernel a chance to reload important cache items
-    # before hitting it with a workload
-    time.sleep(cache_reload_time)
+        # give kernel a chance to reload important cache items
+        # before hitting it with a workload
+        time.sleep(cache_reload_time)
 
 
 if __name__ == '__main__':

--- a/snafu/utils/request_cache_drop.py
+++ b/snafu/utils/request_cache_drop.py
@@ -62,7 +62,8 @@ def drop_cache():
     # drop kernel cache if requested to
 
     kernel_cache_drop_pod_ips = os.getenv('kcache_drop_pod_ips')
-    if kernel_cache_drop_pod_ips.strip() != '':
+    if kernel_cache_drop_pod_ips is not None and \
+       kernel_cache_drop_pod_ips.strip() != '':
         logger.info('kernel cache drop pods: %s' %
                     str(kernel_cache_drop_pod_ips))
         logger.info('debug lvl %d, cachedrop timeout %d, cache reload time %d'

--- a/snafu/utils/request_cache_drop.py
+++ b/snafu/utils/request_cache_drop.py
@@ -8,6 +8,7 @@
 import os
 import http.client
 import logging
+import time
 
 
 def getPortNum(envVar, defaultPort):
@@ -32,16 +33,17 @@ if dbgLevel is not None:
     logger.info('drop_cache debug log level')
 
 http_debug_level = int(os.getenv('HTTP_DEBUG_LEVEL', default=0))
-
-http_timeout = 10
+http_timeout = int(os.getenv('HTTP_CACHEDROP_TIMEOUT', default=30))
+cache_reload_time = int(os.getenv('CACHE_RELOAD_TIME', default=10))
 
 
 # drop Ceph OSD cache if requested to
 
 def drop_cache():
     ceph_cache_drop_pod_ip = os.getenv('ceph_drop_pod_ip')
-    logger.info('ceph OSD cache drop pod: %s' % str(ceph_cache_drop_pod_ip))
     if ceph_cache_drop_pod_ip is not None:
+        logger.info('ceph OSD cache drop pod: %s' %
+                    str(ceph_cache_drop_pod_ip))
         conn = http.client.HTTPConnection(ceph_cache_drop_pod_ip,
                                           port=dropCephCachePort,
                                           timeout=http_timeout)
@@ -60,8 +62,11 @@ def drop_cache():
     # drop kernel cache if requested to
 
     kernel_cache_drop_pod_ips = os.getenv('kcache_drop_pod_ips')
-    logger.info('kernel cache drop pods: %s' % str(kernel_cache_drop_pod_ips))
-    if kernel_cache_drop_pod_ips is not None:
+    if kernel_cache_drop_pod_ips.strip() != '':
+        logger.info('kernel cache drop pods: %s' %
+                    str(kernel_cache_drop_pod_ips))
+        logger.info('debug lvl %d, cachedrop timeout %d, cache reload time %d'
+                    % (http_debug_level, http_timeout, cache_reload_time))
         pod_ip_list = kernel_cache_drop_pod_ips.split()
         for ip in pod_ip_list:
             conn = http.client.HTTPConnection(ip,
@@ -77,6 +82,9 @@ def drop_cache():
                 logger.error('HTTP code %d: %s' % (rsp.status, rsp.reason))
                 raise RunSnafuCacheDropException('kernel cache drop %s:%d' %
                                                  (ip, dropKernelCachePort))
+    # give kernel a chance to reload important cache items
+    # before hitting it with a workload
+    time.sleep(cache_reload_time)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Depends-On: 378
before starting workload by caching directories, shared libraries, etc.
make delay and webservice timeout configurable with env. vars.
do not log cache dropping messages unless user requested cache dropping
tested delay with AWS EC2 cluster 
```
2020-09-09T12:02:27Z - INFO     - MainProcess - request_cache_drop: requesting kernel to drop cache via 10.128.2.64:9222
2020-09-09T12:02:37Z - INFO     - MainProcess - trigger_fio: Executing fio --client...
```