### PR TITLE
corrected if statement on bs||bsrange check

### DIFF
--- a/snafu/fio_wrapper/fio_analyzer.py
+++ b/snafu/fio_wrapper/fio_analyzer.py
@@ -40,9 +40,9 @@ class Fio_Analyzer:
             if fio_result['document']['fio']['jobname'] != 'All clients':
                 sample = fio_result['document']['sample']
 
-                if bool(fio_result['document']['global_options']['bs']):
+                if fio_result['document']['global_options'].get('bs'):
                     bs_value = fio_result['document']['global_options']['bs']
-                elif bool(fio_result['document']['global_options']['bsrange']):
+                elif fio_result['document']['global_options'].get('bsrange'):
                     bs_value = fio_result['document']['global_options']['bsrange']
 
                 rw = fio_result['document']['fio']['job options']['rw']
@@ -67,9 +67,9 @@ class Fio_Analyzer:
             if fio_result['document']['fio']['jobname'] != 'All clients':
                 sample = fio_result['document']['sample']
 
-                if bool(fio_result['document']['global_options']['bs']):
+                if fio_result['document']['global_options'].get('bs'):
                     bs_value = fio_result['document']['global_options']['bs']
-                elif bool(fio_result['document']['global_options']['bsrange']):
+                elif fio_result['document']['global_options'].get('bsrange'):
                     bs_value = fio_result['document']['global_options']['bsrange']
 
                 rw = fio_result['document']['fio']['job options']['rw']


### PR DESCRIPTION
incorrectly used bool(dict) which triggered a keyerror when bs || bsrange were null, instead the proper method to check if a key is within a dict is dict.get(key). 

Have ran though multiple dry runs and captured valid results, please see link below. 

http://marquez.perf.lab.eng.rdu2.redhat.com:3000/d/QdOBqFNGk/fio-summary-with-rook-ceph?orgId=1&from=now-30m&to=now&var-user=acalhoun&var-clustername=acalhoun-ocs-aws-compression-test-1&var-UUID=ffe9f52f-a72d-5400-a2ed-136c072ab2a9&var-Operation=write&var-io_size=1KiB-16KiB&var-io_size=32KiB-256KiB&var-io_size=512KiB-4096KiB&var-interval=$__auto_interval_interval&var-datasource=Alex%20Prometheus%20Remote%20Write&var-net_device=$__all&var-block_device=$__all&var-instances=$__all&var-ceph_pod=$__all 