### PR TITLE
Adding upgrading of openshift clusters

### DIFF
--- a/snafu/upgrade_openshift_wrapper/Dockerfile
+++ b/snafu/upgrade_openshift_wrapper/Dockerfile
@@ -1,0 +1,10 @@
+FROM registry.access.redhat.com/ubi8:latest
+
+COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
+RUN dnf install -y --nodocs python3 python3-pip  && dnf clean all
+RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz -C /usr/bin/ oc
+RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN mkdir -p /opt/snafu/
+COPY . /opt/snafu/
+RUN pip3 install -e /opt/snafu/

--- a/snafu/upgrade_openshift_wrapper/ci_test.sh
+++ b/snafu/upgrade_openshift_wrapper/ci_test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -x
+
+echo "No CI Test for Cluster Upgrade"

--- a/snafu/upgrade_openshift_wrapper/trigger_upgrade.py
+++ b/snafu/upgrade_openshift_wrapper/trigger_upgrade.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import logging
+import time
+import datetime
+import subprocess
+from kubernetes import client, config
+from openshift.dynamic import DynamicClient
+
+logger = logging.getLogger("snafu")
+time_format = "%Y-%m-%dT%H:%M:%S%z"
+
+class Trigger_upgrade():
+    def __init__(self, args):
+        self.uuid = args.uuid
+        self.user = args.user
+        self.version = args.version
+        self.cluster_name = args.cluster_name
+        self.incluster = args.incluster
+        self.poll_interval = args.poll_interval
+        self.timeout = args.timeout
+        self.kubeconfig = args.kubeconfig
+        self.toimage = args.toimage
+        if self.incluster == "true":
+            config.load_incluster_config()
+            k8s_config = client.Configuration()
+            k8s_client = client.api_client.ApiClient(configuration=k8s_config)
+        elif self.kubeconfig:
+            k8s_client = config.new_client_from_config(self.kubeconfig)
+        else:
+            k8s_client = config.new_client_from_config()
+
+        self.dyn_client = DynamicClient(k8s_client)
+
+    def _json_payload(self, data):
+        payload = {
+            "uuid": self.uuid,
+            "cluster_name": self.cluster_name,
+            "init_version": self.init_version,
+            "end_version": self.end_version,
+            "timestamp": self.timestamp,
+            "platform": self.platform,
+            "start_time": self.start_time.strftime(time_format),
+        }
+        payload.update(data)
+        return payload
+
+    def _run_upgrade(self):
+        # Get platform
+        infra = self.dyn_client.resources.get(kind='Infrastructure')
+        platform = infra.get().attributes.items[0].spec.platformSpec.type or "Unknown"
+
+        clusterversion = self.dyn_client.resources.get(kind='ClusterVersion')
+        
+        init_version = clusterversion.get().items[0].status.desired.version
+        logger.info("Current cluster version is: %s" % init_version)
+        logger.info("Desired cluster version is: %s" % self.version)
+
+        # Exit if the current version is already at the desired version
+        if init_version == self.version:
+            logger.info("Cluster version is already at desired version")
+            the_time = datetime.datetime.strptime(
+                self._clusterversion.get().attributes.items[0].status.history[0].completionTime,time_format)
+            return init_version, self.version, platform, the_time, the_time, 0
+
+        # If an image location was passed
+        if self.toimage:
+            cmd = (
+                "oc adm upgrade --to-image={0} --allow-explicit-upgrade=true --force").format(self.toimage)
+        else:
+            cmd = (
+                "oc adm upgrade --to={0}").format(self.version)
+        logger.info(cmd)
+        p = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        if p.returncode == 1:
+            logger.error("Error executing upgrade command. The error was:")
+            logger.error(p.stderr.strip().decode("utf-8"))
+            exit(1)
+
+        logger.info(p)
+
+        before = int(time.time())
+        while self.timeout*60 >= int(time.time()) - before:
+            for i in range(10):
+                try:
+                    c_state = clusterversion.get().attributes.items[0].status.history[0].state
+                except exception:
+                    if i == 10:
+                        logger.error(exception)
+                        exit(1)
+                    else:
+                        logger.warm(exception)
+                        continue
+                else:
+                    break
+            for i in range(10):
+                try:
+                    c_version = clusterversion.get().attributes.items[0].status.history[0].version
+                except exception:
+                    if i == 10:
+                        logger.error(exception)
+                        exit(1)
+                    else:
+                        logger.warm(exception)
+                        continue
+                else:
+                    break
+
+
+            if c_state == "Completed" \
+                and c_version == self.version:
+
+                logger.info("Cluster upgrade complete")
+                logger.info(clusterversion.get().attributes.items[0].status.history[0])
+                break
+            status = ("oc adm upgrade | grep info")
+            s = subprocess.run(status, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            logger.info(s.stdout.strip().decode("utf-8"))
+            time.sleep(self.poll_interval)
+
+        new_version = clusterversion.get().items[0].status.desired.version
+        logger.info("Cluster version post-upgrade is: %s" % new_version)
+
+        start_time = datetime.datetime.strptime(
+            clusterversion.get().attributes.items[0].status.history[0].startedTime,time_format)
+        end_time = datetime.datetime.strptime(
+            clusterversion.get().attributes.items[0].status.history[0].completionTime,time_format)
+        total_time = end_time - start_time
+        logger.info("Total upgrade time: %s" % total_time)
+
+        return init_version, new_version, platform, start_time, end_time, total_time
+
+    def get_timings(self):
+        logger.info("Getting timing stats from cluster Operators")
+
+        operator_infra = self.dyn_client.resources.get(kind='ClusterOperator')
+        operator = operator_infra.get()
+
+        new_docs = [{}]
+        for op in operator.attributes.items:
+            field_len = len(op.metadata.managedFields)
+            op_name = op.metadata.managedFields[field_len-1].manager
+            op_time = datetime.datetime.strptime(op.metadata.managedFields[field_len-1].time,time_format)
+            update_time = op_time - self.start_time
+            op_time = op_time.strftime(time_format)
+            logger.info("Operator: %s finished update at %s and took %s" % (op_name,op_time,update_time))
+            op_data = {"operator": op_name,
+                       "end_time": op_time,
+                       "update_time": str(update_time)}
+            new_docs.append(self._json_payload(op_data))
+
+        return new_docs
+
+    def emit_actions(self):
+        logger.info("Upgrading cluster %s to version %s with uuid %s" %
+                    (self.cluster_name, self.version, self.uuid))
+        self.timestamp = time.strftime("%Y-%m-%dT%H:%M:%S")
+        self.init_version, self.end_version, self.platform, self.start_time, end_time, total_time = \
+            self._run_upgrade()
+        if total_time != 0:
+            docs = self.get_timings()
+        else:
+            docs = []
+        data = {"operator": "total",
+                "end_time": end_time.strftime(time_format),
+                "update_time": str(total_time),
+                "image": self.toimage}
+        docs.append(self._json_payload(data))
+        for item in docs:
+            yield item, ''
+        if self.end_version != self.version:
+            logger.error("Cluster did not upgrade to desired version")
+            logger.error("Cluster version is %s and desired version is %s" %
+                         (self.end_version,self.version))
+            exit(1)
+        logger.info("Finished upgrading the cluster to version %s" %
+                    (self.version))

--- a/snafu/upgrade_openshift_wrapper/trigger_upgrade.py
+++ b/snafu/upgrade_openshift_wrapper/trigger_upgrade.py
@@ -94,10 +94,10 @@ class Trigger_upgrade():
         c_version = "0.0.0"
         before = int(time.time())
         while self.timeout*60 >= int(time.time()) - before and \
-            (c_state != "Completed" and c_version != self.version):
+            (c_state != "Completed" or c_version != self.version):
             for i in range(10):
                 try:
-                    c_state = clusterversion.get().attributes.items[0].status.history[0].state
+                    cluster_state = clusterversion.get().attributes.items[0].status.history[0]
                 except Exception as err:
                     if i == 10:
                         logger.error(err)
@@ -106,18 +106,8 @@ class Trigger_upgrade():
                         logger.warn(err)
                         continue
                 else:
-                    break
-            for i in range(10):
-                try:
-                    c_version = clusterversion.get().attributes.items[0].status.history[0].version
-                except Exception as err:
-                    if i == 10:
-                        logger.error(err)
-                        exit(1)
-                    else:
-                        logger.warn(err)
-                        continue
-                else:
+                    c_state = cluster_state.state
+                    c_version = cluster_state.version
                     break
 
             if c_state == "Completed" \

--- a/snafu/upgrade_openshift_wrapper/upgrade_openshift_wrapper.py
+++ b/snafu/upgrade_openshift_wrapper/upgrade_openshift_wrapper.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import os
+import argparse
+from .trigger_upgrade import Trigger_upgrade
+
+
+class upgrade_openshift_wrapper():
+
+    def __init__(self, parent_parser):
+        parser_object = argparse.ArgumentParser(description="Upgrade Wrapper script", parents=[parent_parser],
+                                                formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        parser = parser_object.add_argument_group("Upgrade benchmark")
+        parser.add_argument(
+            '-u', '--uuid',
+            required=True,
+            help='Provide the uuid')
+        parser.add_argument(
+            '--version',
+            required=True,
+            help='Provide the target version')
+        parser.add_argument(
+            '--toimage',
+            help='Provide the target image location')
+        parser.add_argument(
+            '--user',
+            default="snafu",
+            help='Enter the user')
+        parser.add_argument(
+            '--incluster',
+            default="false",
+            help='Is this running from a pod within the cluster [true|false]')
+        parser.add_argument(
+            '--poll_interval',
+            default="5",
+            type=int,
+            help='Polling interval (in seconds) to wait between checking if the upgrade is complete')
+        parser.add_argument(
+            '--timeout',
+            default="240",
+            type=int,
+            help='Timeout (in minutes) to wait for the upgrade to complete')
+        parser.add_argument(
+            '--kubeconfig',
+            help='Optional kubeconfig location. Incluster cannot be true')
+        self.args = parser_object.parse_args()
+
+        self.args.cluster_name = os.getenv("clustername", "mycluster")
+
+    def run(self):
+        yield Trigger_upgrade(self.args)

--- a/snafu/utils/wrapper_factory.py
+++ b/snafu/utils/wrapper_factory.py
@@ -11,6 +11,7 @@ from snafu.hammerdb.hammerdb_wrapper import hammerdb_wrapper
 from snafu.ycsb_wrapper.ycsb_wrapper import ycsb_wrapper
 from snafu.scale_openshift_wrapper.scale_openshift_wrapper import scale_openshift_wrapper
 from snafu.stressng_wrapper.stressng_wrapper import stressng_wrapper
+from snafu.upgrade_openshift_wrapper.upgrade_openshift_wrapper  import upgrade_openshift_wrapper
 
 import logging
 logger = logging.getLogger("snafu")
@@ -26,7 +27,8 @@ wrapper_dict = {
     "pgbench": pgbench_wrapper,
     "vegeta": vegeta_wrapper,
     "scale": scale_openshift_wrapper,
-    "stressng": stressng_wrapper
+    "stressng": stressng_wrapper,
+    "upgrade": upgrade_openshift_wrapper
 }
 #    "backpack": pgbench_wrapper,
 #    "fio": fio_wrapper,

--- a/snafu/utils/wrapper_factory.py
+++ b/snafu/utils/wrapper_factory.py
@@ -11,7 +11,7 @@ from snafu.hammerdb.hammerdb_wrapper import hammerdb_wrapper
 from snafu.ycsb_wrapper.ycsb_wrapper import ycsb_wrapper
 from snafu.scale_openshift_wrapper.scale_openshift_wrapper import scale_openshift_wrapper
 from snafu.stressng_wrapper.stressng_wrapper import stressng_wrapper
-from snafu.upgrade_openshift_wrapper.upgrade_openshift_wrapper  import upgrade_openshift_wrapper
+from snafu.upgrade_openshift_wrapper.upgrade_openshift_wrapper import upgrade_openshift_wrapper
 
 import logging
 logger = logging.getLogger("snafu")


### PR DESCRIPTION
This will upgrade an openshift cluster and index the timings to elasticsearch

NOTE: There is no CI test for this as it would upgrade the cluster which may not be desired.

Format for executing:
NOTE: A version string is always required even when using --toimage

```
# This assumes that the version is in the supported upgrade path for the cluster. ie
# when oc adm upgrade is run the version is listed
run_snafu --tool upgrade -u 123 --version 4.5.8

or

# This allows you to pass an image to use for the upgrade. The upgrade command is
# then run with --force and --allow-explicit-upgrade=true
# As such this is the more "dangerous" way to run it
run_snafu --tool upgrade -u 123 --toimage registry.svc.ci.openshift.org/ocp/release:4.5.8 --version 4.5.8
```