### PR TITLE
Set workdir for stressng benchmark

### DIFF
--- a/snafu/stressng_wrapper/Dockerfile
+++ b/snafu/stressng_wrapper/Dockerfile
@@ -12,3 +12,7 @@ COPY . /opt/snafu
 RUN pip3 install -e /opt/snafu/
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
+RUN mkdir /opt/stressng &&  \
+    chgrp 0 /opt/stressng && \
+    chmod g+w /opt/stressng
+WORKDIR /opt/stressng


### PR DESCRIPTION
Set writeable WORKDIR for stressng image so output report can be written in an unprivileged pod when running on OpenShift.

This would fix #223 