### PR TITLE
add run_id to es docs

### DIFF
--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -62,7 +62,7 @@ diff_list=`git diff origin/master --name-only | grep -Ev "*\.(md|png)"`
 if [[ ${test_choice} != '' ]]; then
   echo "Running chosen test: "${test_choice}
   test_list=${test_choice}
-elif [[ `echo "${diff_list}" | grep -cv /` -gt 0 || `echo ${diff_list} | grep -E "(ci|utils|image_resources)/|requirements\.txt"` ]]; then
+elif [[ `echo "${diff_list}" | grep -cv /` -gt 0 || `echo ${diff_list} | grep -E "(ci|utils|image_resources)/|snafu/run_snafu\.py|requirements\.txt"` ]]; then
   echo "Running full test"
   test_list=`find * -maxdepth 2 -name ci_test.sh -type f -exec dirname {} \;`
 else

--- a/snafu/run_snafu.py
+++ b/snafu/run_snafu.py
@@ -173,7 +173,6 @@ def get_valid_es_document(action, index, index_args):
         es_index = index_args.prefix + '-' + index
     else:
         es_index = index_args.prefix
-    
     es_valid_document = {"_index": es_index,
                          "_op_type": "create",
                          "_source": action,

--- a/snafu/run_snafu.py
+++ b/snafu/run_snafu.py
@@ -49,7 +49,7 @@ def main():
     parser.add_argument(
         '-t', '--tool', help='Provide tool name', required=True)
     parser.add_argument(
-        '-r', '--run-id', help='Run ID to unify benchmark results in ES'
+        '--run-id', help='Run ID to unify benchmark results in ES'
     )
     index_args, unknown = parser.parse_known_args()
     index_args.index_results = False
@@ -173,10 +173,13 @@ def get_valid_es_document(action, index, index_args):
         es_index = index_args.prefix + '-' + index
     else:
         es_index = index_args.prefix
+    
     es_valid_document = {"_index": es_index,
                          "_op_type": "create",
                          "_source": action,
                          "_id": ""}
+    if index_args.run_id:
+        es_valid_document['run_id'] = index_args.run_id
     es_valid_document["_id"] = hashlib.sha256(str(action).encode()).hexdigest()
     document_size_bytes = sys.getsizeof(es_valid_document)
     index_args.document_size_capacity_bytes += document_size_bytes

--- a/snafu/run_snafu.py
+++ b/snafu/run_snafu.py
@@ -48,6 +48,9 @@ def main():
         default=logging.INFO, help='enables verbose wrapper debugging info')
     parser.add_argument(
         '-t', '--tool', help='Provide tool name', required=True)
+    parser.add_argument(
+        '-r', '--run-id', help='Run ID to unify benchmark results in ES'
+    )
     index_args, unknown = parser.parse_known_args()
     index_args.index_results = False
     index_args.prefix = "snafu-%s" % index_args.tool

--- a/snafu/run_snafu.py
+++ b/snafu/run_snafu.py
@@ -178,7 +178,8 @@ def get_valid_es_document(action, index, index_args):
                          "_source": action,
                          "_id": ""}
     if index_args.run_id:
-        es_valid_document['run_id'] = index_args.run_id
+        logger.debug(f"Run ID is {index_args.run_id}")
+        es_valid_document['run_id'] = action['run_id'] = index_args.run_id
     es_valid_document["_id"] = hashlib.sha256(str(action).encode()).hexdigest()
     document_size_bytes = sys.getsizeof(es_valid_document)
     index_args.document_size_capacity_bytes += document_size_bytes


### PR DESCRIPTION
Adds an optional field `run_id` to the es docs inserted by snafu


example ES doc:

```json
{
    "_index": "snafu-vegeta-results",
    "_op_type": "create",
    "_source": {
        "workload": "vegeta",
        "uuid": "test-uuid",
        "user": "snafu",
        "cluster_name": "mycluster",
        "iteration": 1,
        "duration": 30078961,
        "workers": 1,
        "keepalive": false,
        "targets": "targets.yaml",
        "hostname": "ip-172-31-43-12.us-west-2.compute.internal",
        "rps": 13,
        "throughput": 13,
        "status_codes": {
            "200": 1
        },
        "requests": 404,
        "p99_latency": 208233,
        "p95_latency": 105046,
        "max_latency": 835515,
        "min_latency": 48091,
        "req_latency": 74608,
        "timestamp": "2020-11-11 19:43:24.530419+00:00",
        "bytes_in": 48944,
        "bytes_out": 0
    },
    "_id": "f8db194dde577df56a495ecaccc049a8a2b3e998225bb357896cee74e43be463",
    "run_id": "test-me"
}
```
