### PR TITLE
need to add realpath to resolve relative path to util scripts.

### DIFF
--- a/snafu/utils/get_prometheus_data.py
+++ b/snafu/utils/get_prometheus_data.py
@@ -53,7 +53,7 @@ class get_prometheus_data():
             start_time = time.time()
 
             # resolve directory  the tool include file
-            dirname = os.path.dirname(__file__)
+            dirname = os.path.dirname(os.path.realpath(__file__))
             include_file_dir = os.path.join(dirname, '/utils/prometheus_labels/')
             tool_include_file = include_file_dir + self.sample_info_dict["tool"] + "_included_labels.json"
 


### PR DESCRIPTION
with only using dirname on __file__ and __file__ only being a script name the
directory path resulted in no resolution to the relative path, we can
resolve this by adding realpath.

@dry923 
@rsevilla87 
@jtaleric 