### PR TITLE
ppc64le specific additions for a few workloads

### DIFF
--- a/snafu/fio_wrapper/Dockerfile.ppc64le
+++ b/snafu/fio_wrapper/Dockerfile.ppc64le
@@ -1,0 +1,13 @@
+FROM registry.access.redhat.com/ubi8:latest as builder
+COPY snafu/image_resources/ppc64le/centos8.repo /etc/yum.repos.d/centos8.repo
+RUN dnf install -y --enablerepo=centos8 make gcc libaio zlib-devel libaio-devel
+RUN curl -L https://github.com/axboe/fio/archive/fio-3.19.tar.gz | tar xzf -
+RUN pushd fio-fio-3.19 && ./configure --disable-native && make -j2
+
+FROM registry.access.redhat.com/ubi8:latest
+COPY --from=builder /fio-fio-3.19/fio /usr/local/bin/fio
+RUN dnf install -y --nodocs git python3-pip libaio zlib procps-ng iproute net-tools ethtool nmap iputils python3 gcc python3-devel gcc-c++ atlas-devel gcc-gfortran && dnf clean all
+RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN python3 -m pip install --upgrade cython numpy importlib_metadata 'urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1' && python3 -m pip install --upgrade scipy pandas
+COPY . /opt/snafu
+RUN pip3 install -e /opt/snafu/

--- a/snafu/fs_drift_wrapper/Dockerfile.ppc64le
+++ b/snafu/fs_drift_wrapper/Dockerfile.ppc64le
@@ -1,0 +1,12 @@
+FROM registry.access.redhat.com/ubi8:latest
+
+RUN dnf install -y --nodocs git python3 python3-pip gcc python3-devel gcc-c++ atlas-devel gcc-gfortran
+RUN dnf install -y --nodocs procps-ng iproute net-tools ethtool nmap iputils
+RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN python3 -m pip install --upgrade cython numpy importlib_metadata 'urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1' && python3 -m pip install --upgrade scipy pandas
+COPY . /opt/snafu/
+RUN pip3 install -e /opt/snafu/
+ADD https://api.github.com/repos/parallel-fs-utils/fs-drift/git/refs/heads/master /tmp/bustcache
+RUN git clone https://github.com/parallel-fs-utils/fs-drift /opt/fs-drift --depth 1
+RUN ln -sv /opt/fs-drift/fs-drift.py /usr/local/bin/
+RUN ln -sv /opt/fs-drift/rsptime_stats.py /usr/local/bin/

--- a/snafu/image_resources/ppc64le/centos8-appstream.repo
+++ b/snafu/image_resources/ppc64le/centos8-appstream.repo
@@ -1,0 +1,5 @@
+[centos8-appstream]
+name=CentOS-8-Appstream
+baseurl=http://mirror.centos.org/centos/8/AppStream/ppc64le/os/
+enabled=0
+gpgcheck=0

--- a/snafu/image_resources/ppc64le/centos8.repo
+++ b/snafu/image_resources/ppc64le/centos8.repo
@@ -1,0 +1,5 @@
+[centos8]
+name=CentOS-8
+baseurl=http://mirror.centos.org/centos/8/BaseOS/ppc64le/os/
+enabled=0
+gpgcheck=0

--- a/snafu/iperf/Dockerfile.ppc64le
+++ b/snafu/iperf/Dockerfile.ppc64le
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/ubi8:latest
+
+COPY snafu/image_resources/ppc64le/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
+RUN dnf install -y --nodocs iperf3 --enablerepo=centos8-appstream
+RUN dnf install -y --nodocs procps-ng iproute net-tools ethtool nmap iputils

--- a/snafu/scale_openshift_wrapper/Dockerfile.ppc64le
+++ b/snafu/scale_openshift_wrapper/Dockerfile.ppc64le
@@ -1,0 +1,11 @@
+FROM registry.access.redhat.com/ubi8:latest
+
+COPY snafu/image_resources/ppc64le/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
+RUN dnf install -y --nodocs python3 python3-pip gcc python3-devel gcc-c++ atlas-devel gcc-gfortran && dnf clean all
+RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz -C /usr/bin/ oc
+RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN python3 -m pip install --upgrade cython numpy importlib_metadata 'urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1' && python3 -m pip install --upgrade scipy pandas
+RUN mkdir -p /opt/snafu/
+COPY . /opt/snafu/
+RUN pip3 install -e /opt/snafu/

--- a/snafu/smallfile_wrapper/Dockerfile.ppc64le
+++ b/snafu/smallfile_wrapper/Dockerfile.ppc64le
@@ -1,0 +1,12 @@
+FROM registry.access.redhat.com/ubi8:latest
+
+RUN dnf install -y --nodocs git python3 python3-pip gcc python3-devel gcc-c++ atlas-devel gcc-gfortran
+RUN dnf install -y --nodocs procps-ng iproute net-tools ethtool nmap iputils
+RUN ln -s /usr/bin/python3 /usr/bin/python
+ADD https://api.github.com/repos/distributed-system-analysis/smallfile/git/refs/heads/master /tmp/bustcache
+RUN git clone https://github.com/distributed-system-analysis/smallfile /opt/smallfile --depth 1
+RUN ln -sv /opt/smallfile/smallfile_cli.py /usr/local/bin/
+RUN ln -sv /opt/smallfile/smallfile_rsptimes_stats.py /usr/local/bin/
+RUN python3 -m pip install --upgrade cython numpy importlib_metadata 'urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1' && python3 -m pip install --upgrade scipy pandas
+COPY . /opt/snafu/
+RUN pip3 install -e /opt/snafu/

--- a/snafu/uperf_wrapper/Dockerfile.ppc64le
+++ b/snafu/uperf_wrapper/Dockerfile.ppc64le
@@ -1,0 +1,12 @@
+FROM registry.access.redhat.com/ubi8:latest
+
+RUN dnf install -y --nodocs git python3 python3-pip gcc python3-devel gcc-c++ atlas-devel gcc-gfortran  && dnf clean all
+COPY snafu/image_resources/ppc64le/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
+RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
+RUN dnf install -y --nodocs hostname procps-ng iproute net-tools ethtool nmap iputils https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && dnf clean all
+RUN dnf install -y uperf && dnf clean all
+RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN python3 -m pip install --upgrade cython numpy importlib_metadata 'urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1' && python3 -m pip install --upgrade scipy pandas
+RUN mkdir -p /opt/snafu/
+COPY . /opt/snafu/
+RUN pip3 install -e /opt/snafu/

--- a/snafu/upgrade_openshift_wrapper/Dockerfile.ppc64le
+++ b/snafu/upgrade_openshift_wrapper/Dockerfile.ppc64le
@@ -1,0 +1,11 @@
+FROM registry.access.redhat.com/ubi8:latest
+
+COPY snafu/image_resources/ppc64le/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
+RUN dnf install -y --nodocs python3 python3-pip gcc python3-devel gcc-c++ atlas-devel gcc-gfortran && dnf clean all
+RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz -C /usr/bin/ oc
+RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN python3 -m pip install --upgrade cython numpy importlib_metadata 'urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1' && python3 -m pip install --upgrade scipy pandas
+RUN mkdir -p /opt/snafu/
+COPY . /opt/snafu/
+RUN pip3 install -e /opt/snafu/

--- a/snafu/ycsb_wrapper/Dockerfile.ppc64le
+++ b/snafu/ycsb_wrapper/Dockerfile.ppc64le
@@ -1,0 +1,9 @@
+FROM registry.access.redhat.com/ubi8:latest
+
+RUN curl -L https://github.com/brianfrankcooper/YCSB/releases/download/0.15.0/ycsb-0.15.0.tar.gz | tar xz && mv ycsb-0.15.0 ycsb
+RUN dnf install -y --nodocs https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+RUN dnf install -y --nodocs git java python3 python2 python3-pip procps-ng iproute net-tools ethtool nmap iputils gcc python3-devel gcc-c++ atlas-devel gcc-gfortran && dnf clean all
+RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN python3 -m pip install --upgrade cython numpy importlib_metadata 'urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1' && python3 -m pip install --upgrade scipy pandas
+COPY . /opt/snafu/
+RUN pip3 install -e /opt/snafu/


### PR DESCRIPTION
PR includes - 
- Addition of centos8/appstream repo files for ppc64le in snafu/image_resources/ppc64le/
- Addition of ppc64le specific Dockerfiles for iperf3, fs-drift, fio, ycsb, smallfile, upgrade-openshift, scale-openshift and uperf

PR fixes  https://github.com/cloud-bulldozer/benchmark-wrapper/issues/228 and partially addresses https://github.com/cloud-bulldozer/benchmark-operator/issues/387

PR Does NOT include - 
- ppc64le specific Dockerfiles for oslat, hammerdb, sysbench, pgbench, cyclictest, vegeta due to missing dependencies mentioned here - https://github.com/cloud-bulldozer/benchmark-wrapper/issues/228#issuecomment-740611630

Images built using these Dockerfiles - 
```
quay.io/piyushgupta1551/iperf3-m:ppc64le
quay.io/piyushgupta1551/fs-drift-m:ppc64le
quay.io/piyushgupta1551/fio-m:ppc64le
quay.io/piyushgupta1551/ycsb-m:ppc64le
quay.io/piyushgupta1551/smallfile-m:ppc64le
quay.io/piyushgupta1551/upgrade-m:ppc64le
quay.io/piyushgupta1551/scale-openshift-m:ppc64le
quay.io/piyushgupta1551/uperf-m:ppc64le
```