### PR TITLE
remove the part which alters the test duration

### DIFF
--- a/snafu/vegeta_wrapper/trigger_vegeta.py
+++ b/snafu/vegeta_wrapper/trigger_vegeta.py
@@ -96,7 +96,6 @@ class Trigger_vegeta():
             ltcy = int(data["latencies"]["mean"] / 1000)
             max_ltcy = int(data["latencies"]["max"] / 1000)
             min_ltcy = int(data["latencies"]["min"] / 1000)
-            self.duration = int(data["duration"] / 1000)
             ts = dateutil.parser.parse(data["end"])
             yield {
                 "rps": rps,


### PR DESCRIPTION
to avoid 
```
2021-01-26T00:12:20Z - INFO     - MainProcess - trigger_vegeta: Starting vegeta sample 1 out of 2 with uuid 8f6c430d-23cc-5e7a-99de-2a509d942eb9
2021-01-26T00:12:20Z - INFO     - MainProcess - trigger_vegeta: vegeta attack -keepalive=True -insecure -workers=100 -duration=1s -targets=/tmp/vegeta/100w-ka -rate=0 -max-workers=100 | vegeta report --every=1s --type=json --output=vegeta.log
2021-01-26T00:12:31Z - INFO     - MainProcess - trigger_vegeta: Finished executing vegeta sample 1 out of 2
2021-01-26T00:12:31Z - INFO     - MainProcess - trigger_vegeta: Starting vegeta sample 2 out of 2 with uuid 8f6c430d-23cc-5e7a-99de-2a509d942eb9
2021-01-26T00:12:31Z - INFO     - MainProcess - trigger_vegeta: vegeta attack -keepalive=True -insecure -workers=100 -duration=1000245s -targets=/tmp/vegeta/100w-ka -rate=0 -max-workers=100 | vegeta report --every=1s --type=json --output=vegeta.log
[root@ip-172-31-56-204 benchmark-operator]# oc describe pod vegeta-0-8f6c430d-8p47m 
``` 
checkout `-duration` ^^