### PR TITLE
add a case where additional params are not passed

### DIFF
--- a/snafu/uperf_wrapper/trigger_uperf.py
+++ b/snafu/uperf_wrapper/trigger_uperf.py
@@ -78,13 +78,13 @@ class Trigger_uperf():
                 "num_pairs": self.num_pairs,
                 "multus_client": self.multus_client,
                 "networkpolicy": self.networkpolicy,
-                "density": int(self.pod_density),
-                "nodes_in_iter":int(self.nodes_in_iter),
+                "density": int(self.pod_density or 0),
+                "nodes_in_iter":int(self.nodes_in_iter or 0),
                 "step_size" : self.step_size,
                 "colocate" : self.colocate,
-                "density_range" : [int(x) for x in self.density_range.split('-')],
-                "node_range" : [int(x) for x in self.node_range.split('-')],
-                "pod_id" : int(self.pod_id)
+                "density_range" : [int(x) for x in self.density_range.split('-')] if self.density_range else None,
+                "node_range" : [int(x) for x in self.node_range.split('-')] if self.density_range else None,
+                "pod_id" : int(self.pod_id or 0)
 
             }
             datapoint.update(data)


### PR DESCRIPTION
This commit is a patch for the error caused by the [earlier commit](https://github.com/cloud-bulldozer/benchmark-operator/pull/525/files)
```
Traceback (most recent call last):                                                                                             │            num_threads:
  File "/usr/local/bin/run_snafu", line 33, in <module>                                                                        │              1:
    sys.exit(load_entry_point('snafu', 'console_scripts', 'run_snafu')())                                                      │                50.0percentiles(norm_byte):
  File "/opt/snafu/snafu/run_snafu.py", line 103, in main                                                                      │                  ad273797-562b-5b2b-af41-6cb957535d9b: 183025664.0
    parallel_setting)                                                                                                          │                avg(norm_byte):
  File "/opt/snafu/snafu/utils/py_es_bulk.py", line 168, in streaming_bulk                                                     │                  ad273797-562b-5b2b-af41-6cb957535d9b: 181665700.97777778
    for ok, resp_payload in streaming_bulk_generator:                                                                          │                max(norm_byte):
  File "/usr/local/lib/python3.6/site-packages/elasticsearch/helpers/actions.py", line 212, in streaming_bulk                  │                  ad273797-562b-5b2b-af41-6cb957535d9b: 187252736.0
    actions, chunk_size, max_chunk_bytes, client.transport.serializer                                                          │          16384:
  File "/usr/local/lib/python3.6/site-packages/elasticsearch/helpers/actions.py", line 63, in _chunk_actions                   │            num_threads:
    for action, data in actions:                                                                                               │              1:
  File "/opt/snafu/snafu/utils/py_es_bulk.py", line 114, in actions_tracking_closure                                           │                50.0percentiles(norm_byte):
    for cl_action in cl_actions:                                                                                               │                  ad273797-562b-5b2b-af41-6cb957535d9b: 1287913472.0
  File "/opt/snafu/snafu/run_snafu.py", line 138, in process_generator                                                         │                avg(norm_byte):
    for action, index in data_object.emit_actions():                                                                           │                  ad273797-562b-5b2b-af41-6cb957535d9b: 1285073822.7486033
  File "/opt/snafu/snafu/uperf_wrapper/trigger_uperf.py", line 136, in emit_actions                                            │                max(norm_byte):
    documents = self._json_payload(results, data, s)                                                                           │                  ad273797-562b-5b2b-af41-6cb957535d9b: 1323302912.0
  File "/opt/snafu/snafu/uperf_wrapper/trigger_uperf.py", line 85, in _json_payload                                            │+ set +x
    "density_range" : [int(x) for x in self.density_range.split('-')],                                                         │gold,test_cloud_aws_4.6.13
  File "/opt/snafu/snafu/uperf_wrapper/trigger_uperf.py", line 85, in <listcomp>                                               │ad273797-562b-5b2b-af41-6cb957535d9b,4766b23c-ad7f-5690-906a-d50cd3836ea0
    "density_range" : [int(x) for x in self.density_range.split('-')],                                                         │
ValueError: invalid literal for int() with base 10: ''  
```

encountered same error for https://github.com/cloud-bulldozer/benchmark-wrapper/blob/491034d760def7623dd0ccf48d8c71f6bfa13b15/snafu/uperf_wrapper/trigger_uperf.py#L81