### PR TITLE
Adding log generator script and container file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ environments, develop in SNAFU and then write benchmark-operator benchmark to in
 | smallfile                      | metadata-intensive ops | Working            |
 | fs-drift                       | metadata-intensive mix | Working            |
 | cyclictest                     | Real-Time Latency      | Working            |
-| oslat                          | Real-Time Latency      | Working            |
+| oslat                          | Real-Time Latency              | Working            |
+| OpenShift Upgrade              | Time to upgrade                | Working            |
+| OpenShift Scaling              | Time to scale                  | Working            |
+| Log Generator                  | Log throughput to backend      | Working            |
 
 ## What backend storage do we support?
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ zip_safe = False
 packages = find:
 include_package_data = True
 # Add here dependencies of your project (semicolon/line-separated), e.g.
-install_requires = configparser; elasticsearch>=6.0.0,<=7.0.2; statistics; numpy; pyyaml; requests; redis; python-dateutil>=2.7.3; prometheus_api_client; scipy; openshift; setuptools>=40.3.0; flent
+install_requires = configparser; elasticsearch>=6.0.0,<=7.0.2; statistics; numpy; pyyaml; requests; redis; python-dateutil>=2.7.3; prometheus_api_client; scipy; openshift==0.11; kubernetes==11; setuptools>=40.3.0; boto3; flent
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ zip_safe = False
 packages = find:
 include_package_data = True
 # Add here dependencies of your project (semicolon/line-separated), e.g.
-install_requires = configparser; elasticsearch>=6.0.0,<=7.0.2; statistics; numpy; pyyaml; requests; redis; python-dateutil>=2.7.3; prometheus_api_client; scipy; openshift==0.11; kubernetes==11; setuptools>=40.3.0; boto3; flent
+install_requires = configparser; elasticsearch>=6.0.0,<=7.0.2; statistics; numpy; pyyaml; requests; redis; python-dateutil>=2.7.3; prometheus_api_client; scipy; openshift==0.11; kubernetes==11; setuptools>=40.3.0; boto3; flent; importlib_metadata
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.6

--- a/snafu/log_generator_wrapper/Dockerfile
+++ b/snafu/log_generator_wrapper/Dockerfile
@@ -1,0 +1,10 @@
+FROM registry.access.redhat.com/ubi8:latest
+
+COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
+RUN dnf install -y --nodocs python3 python3-pip && dnf clean all
+RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz -C /usr/bin/ oc
+RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN mkdir -p /opt/snafu/
+COPY . /opt/snafu/
+RUN pip3 install -e /opt/snafu/

--- a/snafu/log_generator_wrapper/ci_test.sh
+++ b/snafu/log_generator_wrapper/ci_test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -x
+
+source ci/common.sh
+
+# Build image for ci
+image_spec=$SNAFU_WRAPPER_IMAGE_PREFIX/log_generator:$SNAFU_IMAGE_TAG
+build_and_push snafu/log_generator_wrapper/Dockerfile $image_spec
+pushd ripsaw
+source tests/test_log_generator.sh

--- a/snafu/log_generator_wrapper/log_generator_wrapper.py
+++ b/snafu/log_generator_wrapper/log_generator_wrapper.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import os
+import argparse
+from .trigger_log_generator import Trigger_log_generator
+
+
+class log_generator_wrapper():
+
+    def __init__(self, parent_parser):
+        parser_object = argparse.ArgumentParser(description="Log Generator Wrapper script",
+                                                parents=[parent_parser],
+                                                formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        parser = parser_object.add_argument_group("Log Generator")
+        parser.add_argument(
+            '-u', '--uuid',
+            required=True,
+            help='Provide the uuid')
+        parser.add_argument(
+            '--size',
+            type=int,
+            required=True,
+            help='Size in bytes of a message')
+        parser.add_argument(
+            '--messages-per-minute',
+            type=int,
+            help='How many messages to send in one minute')
+        parser.add_argument(
+            '--messages-per-second',
+            type=int,
+            help='How many messages to send in one second')
+        parser.add_argument(
+            '--duration',
+            type=int,
+            required=True,
+            help='How long to run the test for in minutes')
+        parser.add_argument(
+            '--user',
+            default="snafu",
+            help='Enter the user')
+        parser.add_argument(
+            '--pod-count',
+            type=int,
+            default=1,
+            help='Total number of log generator pods to run')
+        parser.add_argument(
+            '--redisip',
+            help='IP address for redis server')
+        parser.add_argument(
+            '--redisport',
+            type=int,
+            default=6379,
+            help='Port for the redis server')
+        parser.add_argument(
+            '--pod-name',
+            default=None,
+            help='Pod Name of log generator')
+        parser.add_argument(
+            '--namespace',
+            default=None,
+            help='Namespace log generator lives in')
+        parser.add_argument(
+            '--timeout',
+            type=int,
+            default=600,
+            help='Max amount of time (in seconds) to wait for the backend service\
+                  to obtain all the logs once the test is complete')
+        parser.add_argument(
+            '--cloudwatch-log-group',
+            help='The cloudwatch log group to check for messages')
+        parser.add_argument(
+            '--aws-access-key',
+            default=None,
+            help='AWS access key id used for verification with cloudwatch')
+        parser.add_argument(
+            '--aws-secret-key',
+            default=None,
+            help='AWS secret key used for verification with cloudwatch')
+        parser.add_argument(
+            '--aws-region',
+            default=None,
+            help='AWS region that CloudWatch is in')
+        parser.add_argument(
+            '--es-url',
+            help='Provide elastic server url')
+        parser.add_argument(
+            '--es-token',
+            help='Bearer token to access ES server')
+        parser.add_argument(
+            '--es-index',
+            type=str,
+            default="app*",
+            help='The ES index to search for the messages')
+        parser.add_argument(
+            '--incluster',
+            default="false",
+            help='Is this running from a pod within the cluster [true|false]')
+        parser.add_argument(
+            '--kubeconfig',
+            help='Optional kubeconfig location. Incluster cannot be true')
+
+        self.args = parser_object.parse_args()
+
+        self.args.cluster_name = os.getenv("clustername", "mycluster")
+
+    def run(self):
+        yield Trigger_log_generator(self.args)

--- a/snafu/log_generator_wrapper/log_generator_wrapper.py
+++ b/snafu/log_generator_wrapper/log_generator_wrapper.py
@@ -55,14 +55,6 @@ class log_generator_wrapper():
             default=1,
             help='Total number of log generator pods to run')
         parser.add_argument(
-            '--redisip',
-            help='IP address for redis server')
-        parser.add_argument(
-            '--redisport',
-            type=int,
-            default=6379,
-            help='Port for the redis server')
-        parser.add_argument(
             '--pod-name',
             default=None,
             help='Pod Name of log generator')
@@ -102,13 +94,6 @@ class log_generator_wrapper():
             type=str,
             default="app*",
             help='The ES index to search for the messages')
-        parser.add_argument(
-            '--incluster',
-            default="false",
-            help='Is this running from a pod within the cluster [true|false]')
-        parser.add_argument(
-            '--kubeconfig',
-            help='Optional kubeconfig location. Incluster cannot be true')
 
         self.args = parser_object.parse_args()
 

--- a/snafu/log_generator_wrapper/trigger_log_generator.py
+++ b/snafu/log_generator_wrapper/trigger_log_generator.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import sys
+import datetime
+import time
+from time import sleep
+import random
+import string
+import logging
+import redis
+import boto3
+import json
+import subprocess
+
+logger = logging.getLogger("snafu")
+
+
+class Trigger_log_generator():
+    def __init__(self, args):
+        self.uuid = args.uuid
+        self.cluster_name = args.cluster_name
+        self.user = args.user
+        self.size = args.size
+        self.messages_per_minute = args.messages_per_minute
+        self.messages_per_second = args.messages_per_second
+        self.duration = args.duration
+        self.pod_count = args.pod_count
+        self.redisip = args.redisip
+        self.redisport = args.redisport
+        self.pod_name = args.pod_name
+        self.namespace = args.namespace
+        self.timeout = args.timeout
+        self.cloudwatch_log_group = args.cloudwatch_log_group
+        self.aws_access_key = args.aws_access_key
+        self.aws_secret_key = args.aws_secret_key
+        self.aws_region = args.aws_region
+        self.es_url = args.es_url
+        self.es_token = args.es_token
+        self.es_index = args.es_index
+
+        if self.messages_per_minute:
+            self.total_messages = self.messages_per_minute * self.duration
+            self.messages_per_second = self.messages_per_minute / 60
+        elif args.messages_per_second:
+            self.total_messages = self.messages_per_second * 60 * self.duration
+            self.messages_per_second = self.messages_per_second
+        else:
+            print("NO RATE DEFINED EXITING")
+            exit(1)
+        self.delay = 1 / self.messages_per_second
+        self.my_message = ''.join(random.choice(string.ascii_uppercase + string.digits)
+                                  for x in range(self.size))
+
+    def _json_payload(self, data):
+        payload = {
+            "uuid": self.uuid,
+            "cluster_name": self.cluster_name,
+            "pod_name": self.pod_name,
+            "expected_duration": self.duration * 60,
+            "total_expected_messages": self.total_messages,
+            "messages_per_second": self.messages_per_second,
+            "messages_per_minute": self.messages_per_minute,
+            "message_size": self.size,
+            "timeout": self.timeout,
+            "pod_count": self.pod_count,
+            "user": self.user
+        }
+        if self.cloudwatch_log_group:
+            backend = {
+                "cloudwatch_log_group": self.cloudwatch_log_group,
+                "backend": "cloudwatch"
+            }
+            payload.update(backend)
+        elif self.es_url:
+            backend = {
+                "es_url": self.es_url,
+                "es_index": self.es_index,
+                "backend": "elasticsearch"
+            }
+            payload.update(backend)
+        payload.update(data)
+        return payload
+
+    def _run_log_test(self):
+        # Custom logging settings for log tests
+        gen_logger = logging.getLogger("logGen")
+        gen_logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setLevel(logging.DEBUG)
+        formatter = logging.Formatter('%(message)s')
+        handler.setFormatter(formatter)
+        gen_logger.addHandler(handler)
+        count = 0
+        while count < self.total_messages:
+            if self.messages_per_minute:
+                gen_logger.info(self.my_message)
+                sleep(self.delay)
+                count += 1
+            else:
+                t = datetime.datetime.now()
+                for x in range(0, self.messages_per_second):
+                    gen_logger.info(self.my_message)
+                tdiff = datetime.datetime.now() - t
+                total_diff = tdiff.seconds + (tdiff.microseconds / 1000000)
+                if total_diff < 1:
+                    sleep(1 - total_diff)
+                count += self.messages_per_second
+        return count
+
+    def _wait_for_pods(self,my_redis,channel):
+        subchannel = my_redis.pubsub()
+        subchannel.subscribe(channel)
+        subscribers = dict(my_redis.pubsub_numsub(channel))[channel]
+        while subscribers < self.pod_count:
+            sleep(1)
+            subscribers = dict(my_redis.pubsub_numsub(channel))[channel]
+        # Sleep 10 to ensure all pods are ready and allow any lingering messages to clear
+        sleep(10)
+        subchannel.unsubscribe(channel)
+
+    def _check_cloudwatch(self,start_time,end_time):
+        logger.info("Checking CloudWatch for expected messages")
+        if self.aws_access_key is not None and self.aws_secret_key is not None:
+            client = boto3.client(service_name='logs',
+                                  region_name=self.aws_region,
+                                  aws_access_key_id=self.aws_access_key,
+                                  aws_secret_access_key=self.aws_secret_key)
+        else:
+            client = boto3.client(service_name='logs', region_name=self.aws_region)
+
+        query = "fields @timestamp, @message | filter message = \""\
+                + self.my_message + "\" | stats count()"
+
+        start_query_response = client.start_query(
+            logGroupName=self.cloudwatch_log_group,
+            startTime=start_time - 60,
+            endTime=end_time + 60,
+            queryString=query
+        )
+
+        running = True
+        while running:
+            query_status = client.describe_queries(
+                logGroupName=self.cloudwatch_log_group
+            )
+            for x in range(0,len(query_status['queries'])):
+                if query_status['queries'][x]['queryId'] == start_query_response.get('queryId'):
+                    if query_status['queries'][x]['status'] == "Complete":
+                        running = False
+            sleep(1)
+
+        query_results = client.get_query_results(queryId=start_query_response.get('queryId'))
+        return int(query_results['statistics']['recordsMatched'])
+
+    def _check_es(self,start_time,end_time):
+        logger.info("Checking ElasticSearch for expected messages")
+        header_json = 'Content-Type: application/json'
+        header_auth = "Authorization: Bearer " + self.es_token
+        s_time = datetime.datetime.fromtimestamp(start_time - 60).strftime("%Y-%m-%dT%H:%M:%S")
+        e_time = datetime.datetime.fromtimestamp(end_time + 60).strftime("%Y-%m-%dT%H:%M:%S")
+        data = {
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "match": {
+                                "message": self.my_message
+                            }
+                        }
+                    ],
+                    "filter": [
+                        {
+                            "range": {
+                                "@timestamp": {
+                                    "gte": s_time,
+                                    "lte": e_time
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+        es_url = self.es_url + "/" + self.es_index + "/_count"
+
+        try:
+            response = subprocess.check_output(['curl','--insecure','--header',header_auth,
+                                                '--header',header_json,es_url,'-d',json.dumps(data),
+                                                '-s']).decode("utf-8")
+        except Exception as err:
+            logging.info("ElasticSearch query failed")
+            logging.info(err)
+            return 0
+        try:
+            return(json.loads(response)['count'])
+        except Exception as err:
+            logging.info("No valid json returned")
+            logging.info(err)
+            return 0
+
+    def emit_actions(self):
+        logger.info("Running log test with %d byte size for %d minutes at a rate of %d messages per second" %
+                    (self.size, self.duration, self.messages_per_second))
+        logger.info("Test UUID is %s on cluster %s" % (self.uuid, self.cluster_name))
+
+        logger.info("Waiting for all pods to be ready")
+        # Check redis for all running pods
+        if self.redisip is not None\
+            and self.redisport is not None\
+            and self.pod_name is not None\
+            and self.uuid is not None\
+            and self.pod_count != 1:
+            my_redis = redis.StrictRedis(
+                host=self.redisip,
+                port=self.redisport,
+                charset="utf-8",
+                decode_responses=True)
+            channel = "log-generator-" + self.uuid
+            self._wait_for_pods(my_redis,channel)
+
+        timestamp = time.strftime("%Y-%m-%dT%H:%M:%S")
+        start_time = time.time()
+        message_count = self._run_log_test()
+        end_time = time.time()
+        elapsed_time = end_time - start_time
+
+        logger.info("All messages sent")
+
+        if self.cloudwatch_log_group or self.es_url:
+            logger.info("Confirming all %d messages received in backend" % (message_count))
+            received_all_messages = False
+            current_time = time.time()
+            while not received_all_messages and current_time <= end_time + self.timeout:
+                if self.cloudwatch_log_group:
+                    messages_received = self._check_cloudwatch(int(start_time),int(end_time))
+                else:
+                    messages_received = self._check_es(int(start_time),int(end_time))
+                if messages_received == message_count:
+                    received_all_messages = True
+                else:
+                    logger.info("Message check failed. Retrying until timeout")
+                    sleep(1)
+                    current_time = time.time()
+                post_complete_time = time.time() - end_time
+                message_confirmed_received = {"messages_confirmed_received": received_all_messages,
+                                              "messages_received": messages_received,
+                                              "post_complete_time": int(post_complete_time)}
+            if not received_all_messages:
+                logger.info("Not all messages received by backend.")
+                logger.info("Total messages received: %d Total messages expected: %d" %
+                            (messages_received, message_count))
+                logger.info("Seconds backend waited for messages: %d" %
+                            (int(post_complete_time)))
+            else:
+                logger.info("All messages received by backend")
+                logger.info("Total messages received: %d Total messages expected: %d" %
+                            (messages_received, message_count))
+                logger.info("Seconds till backend received all messages: %d" %
+                            (int(post_complete_time)))
+
+        data = {"timestamp": timestamp,
+                "actual_duration": int(elapsed_time),
+                "message_count": message_count}
+
+        if self.cloudwatch_log_group or self.es_url:
+            data.update(message_confirmed_received)
+
+        es_data = self._json_payload(data)
+        yield es_data, 'results'
+        logger.info("Finished executing logging test")

--- a/snafu/scale_openshift_wrapper/trigger_scale.py
+++ b/snafu/scale_openshift_wrapper/trigger_scale.py
@@ -46,7 +46,7 @@ class Trigger_scale():
 
         if self.incluster == "true":
             config.load_incluster_config()
-            k8s_config = client.Configuration().get_default_copy()
+            k8s_config = client.Configuration()
             k8s_client = client.api_client.ApiClient(configuration=k8s_config)
         elif self.kubeconfig:
             k8s_client = config.new_client_from_config(self.kubeconfig)

--- a/snafu/trex_wrapper/trigger_trex.py
+++ b/snafu/trex_wrapper/trigger_trex.py
@@ -51,10 +51,10 @@ class Trigger_trex():
         # command to run burst script with a 10 sec buffer to trex service
         burst_cmd = "sleep 10 && run_simple_burst"
         # TRex server process
-        subprocess.Popen(trex_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, 
+        subprocess.Popen(trex_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                          close_fds=True)
         # Burst script execution process
-        burst_process = subprocess.Popen(burst_cmd, shell=True, stdout=subprocess.PIPE, 
+        burst_process = subprocess.Popen(burst_cmd, shell=True, stdout=subprocess.PIPE,
                                          stderr=subprocess.PIPE)
         stdout, stderr = burst_process.communicate()
         return stdout.strip().decode("utf-8"), stderr.strip().decode("utf-8"), burst_process.returncode

--- a/snafu/utils/wrapper_factory.py
+++ b/snafu/utils/wrapper_factory.py
@@ -1,5 +1,4 @@
 
-# from backpack_wrapper.backpack_wrapperimport backpack_wrapper
 from snafu.vegeta_wrapper.vegeta_wrapper import vegeta_wrapper
 from snafu.fio_wrapper.fio_wrapper import fio_wrapper
 from snafu.smallfile_wrapper.smallfile_wrapper import smallfile_wrapper
@@ -16,6 +15,7 @@ from snafu.cyclictest_wrapper.cyclictest_wrapper import cyclictest_wrapper
 from snafu.oslat_wrapper.oslat_wrapper import oslat_wrapper
 from snafu.trex_wrapper.trex_wrapper import trex_wrapper
 from snafu.flent_wrapper.flent_wrapper import flent_wrapper
+from snafu.log_generator_wrapper.log_generator_wrapper import log_generator_wrapper
 
 import logging
 logger = logging.getLogger("snafu")
@@ -36,12 +36,10 @@ wrapper_dict = {
     "cyclictest": cyclictest_wrapper,
     "oslat": oslat_wrapper,
     "trex": trex_wrapper,
-    "flent": flent_wrapper
+    "flent": flent_wrapper,
+    "log_generator": log_generator_wrapper
+
 }
-#    "backpack": pgbench_wrapper,
-#    "fio": fio_wrapper,
-#    "uperf": uperf_wrapper
-#    }
 
 def wrapper_factory(tool_name, parser):
     try:


### PR DESCRIPTION
Depends-On: 545

# Description
Adding a log generator workload that will generate X messages of Y size (in bytes) per second/minute over a duration of Z minutes. If provided it will also check the backed log aggregator to confirm it received the expected number of messages. Supported backends are elasticsearch and AWS cloudwatch.

NOTE: This requires a backend storage to be deployed if we want to create a valid ci test for this.

benchmark-operator PR: https://github.com/cloud-bulldozer/benchmark-operator/pull/545