### PR TITLE
Fixing Scale Kubernetes Client Configuration

### DIFF
--- a/snafu/scale_openshift_wrapper/trigger_scale.py
+++ b/snafu/scale_openshift_wrapper/trigger_scale.py
@@ -46,7 +46,7 @@ class Trigger_scale():
 
         if self.incluster == "true":
             config.load_incluster_config()
-            k8s_config = client.Configuration()
+            k8s_config = client.Configuration().get_default_copy()
             k8s_client = client.api_client.ApiClient(configuration=k8s_config)
         elif self.kubeconfig:
             k8s_client = config.new_client_from_config(self.kubeconfig)

--- a/snafu/scale_openshift_wrapper/trigger_scale.py
+++ b/snafu/scale_openshift_wrapper/trigger_scale.py
@@ -53,10 +53,20 @@ class Trigger_scale():
         else:
             k8s_client = config.new_client_from_config()
 
-        dyn_client = DynamicClient(k8s_client)
+        try:
+            dyn_client = DynamicClient(k8s_client)
+        except Exception as err:
+            logger.info("ERROR: Could not configure client, failing the run")
+            logger.info(err)
+            exit(1)
 
-        nodes = dyn_client.resources.get(api_version='v1', kind='Node')
-        machinesets = dyn_client.resources.get(kind='MachineSet')
+        try:
+            nodes = dyn_client.resources.get(api_version='v1', kind='Node')
+            machinesets = dyn_client.resources.get(kind='MachineSet')
+        except Exception as err:
+            logger.info("ERROR: Could not get information on nodes/machinesets, failing the run")
+            logger.info(err)
+            exit(1)
 
         worker_count = \
             len(nodes.get(


### PR DESCRIPTION
This is due to https://github.com/kubernetes-client/python/issues/1284 which is present in the Python Kubernetes Client with version v12 and higher. Looks like the latest version of the openshift client now pulls in a v12 K8s client which is causing this problem. 

This comment https://github.com/kubernetes-client/python/issues/1284#issuecomment-750737547 recommends this fix. I also added some exception handling so that the process doesn't exit 0 when it actually failed