### PR TITLE
es_verify_cert is expected to be a lowercase string

### DIFF
--- a/snafu/run_snafu.py
+++ b/snafu/run_snafu.py
@@ -67,7 +67,7 @@ def main():
     # instantiate elasticsearch instance and check connection
     es_settings = {}
     es_settings["server"] = os.getenv("es")
-    es_settings["verify_cert"] = os.getenv("es_verify_cert", "true")
+    es_settings["verify_cert"] = os.getenv("es_verify_cert", "true").lower()
     if es_settings["server"] and ":443" in es_settings["server"]:
         es_settings["verify_cert"] = "false"
     if es_settings["server"]:


### PR DESCRIPTION
I was going to open an issue with benchmark-operator, but I feel the fix belongs in the wrapper. After updating my local benchmark-operator repo, I have been unable to connect to my self-signed Elasticsearch instance.

Recently the Benchmark CRD `elasticsearch.verify_cert` [field was set to a boolean](https://github.com/cloud-bulldozer/benchmark-operator/blob/2b45608442a8fa75ff5f5d5ec415ef28c2a99ac2/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml#L35-L36). It was previously a string to support how the benchmark-wrapper handles it. Because of this, when `verify_cert` is set and added to templates, the string becomes capitalized during the python boolean to string conversion.

To fix this in the benchmark-operator, to make sure it always output a lowercase string can be fragile when there are so many templates to maintain and the ability to Bring-Your-Own-Workload.

Instead, I propose we make benchmark-wrapper more forgiving of env input, at a minimum converting the relevant input to lowercase.