### PR TITLE
Add DNS performance workload wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ environments, develop in SNAFU and then write benchmark-operator benchmark to in
 | Log Generator                  | Log throughput to backend      | Working            |
 | Image Pull                     | Time to copy from a container image from a repo | Working |
 | sysbench                       | CPU,Memory,Mutex,Threads,Fileio | Working |
+| DNS-Perf                       | DNS Performance                | Working            |
 
 ## What backend storage do we support?
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ zip_safe = False
 packages = find:
 include_package_data = True
 # Add here dependencies of your project (semicolon/line-separated), e.g.
-install_requires = configparser; elasticsearch>=6.0.0,<=7.0.2; statistics; numpy; pyyaml; requests; redis; python-dateutil>=2.7.3; prometheus_api_client; scipy; openshift==0.11; kubernetes==11; setuptools>=40.3.0; boto3; flent; importlib_metadata; kafka-python
+install_requires = configparser; elasticsearch>=6.0.0,<=7.0.2; statistics; numpy; pyyaml; requests; redis; python-dateutil>=2.7.3; prometheus_api_client; scipy; openshift==0.11; kubernetes==11; setuptools>=40.3.0; boto3; flent; importlib_metadata; kafka-python; ttp
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.6

--- a/snafu/dns_perf_wrapper/Dockerfile
+++ b/snafu/dns_perf_wrapper/Dockerfile
@@ -1,0 +1,11 @@
+FROM registry.centos.org/centos:8
+
+COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
+RUN dnf install -y epel-release && dnf install -y --nodocs redis python3 python3-pip openssl-devel ck-devel yum-plugin-copr && \
+    dnf copr enable @dnsoarc/dnsperf -y && \
+    dnf install dnsperf -y && \
+    dnf clean all && rm -rf /var/cache/yum
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz -C /usr/bin/ oc && ln -s /usr/bin/python3 /usr/bin/python
+RUN mkdir -p /opt/snafu/
+COPY . /opt/snafu/
+RUN pip3 install -e /opt/snafu/

--- a/snafu/dns_perf_wrapper/Readme.md
+++ b/snafu/dns_perf_wrapper/Readme.md
@@ -1,0 +1,88 @@
+## DNS Performance Workload Wrapper
+Wrapper around [dnsperf](https://github.com/DNS-OARC/dnsperf) to measure throughput ( requests per second ) and latency metrics for Domain Name Service ( DNS ). The collected metrics are scraped to generate a json which can be indexed into Elasticsearch datastore.
+
+
+### Dependencies
+This wrapper requires a couple of dependencies as well as enabling copr repo to download the latest dnsperf package. For more details [see[(https://github.com/DNS-OARC/dnsperf/blob/master/README.md). It's recommended to build and run the [containerized version](Dockerfile) to avoid managing the installation on the host. Here are the dependencies which need to be installed when running the standalone version:
+- python3
+- python3-pip
+- openssl-devel
+- epel-release
+- ck-devel
+- yum-plugin-copr
+- dnsperf ( Run $ dnf copr enable @dnsoarc/dnsperf and $ dnf install dnsperf to enable the repo to install it )
+
+
+### Run
+```
+usage: run_snafu [-h] [-v] -t TOOL [--run-id [RUN_ID]] -u UUID --server-address SERVER_ADDRESS --queries-per-second QUERIES_PER_SECOND --run-time RUN_TIME --data-file DATA_FILE [--clients CLIENTS]
+
+DNS perf workload Wrapper script
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -v, --verbose         enables verbose wrapper debugging info (default: 20)
+  -t TOOL, --tool TOOL  Provide tool name (default: None)
+  --run-id [RUN_ID]     Run ID to unify benchmark results in ES (default: NA)
+
+DNS Perf:
+  -u UUID, --uuid UUID  Provide the uuid (default: None)
+  --server-address SERVER_ADDRESS
+                        DNS server address to send the requests (default: None)
+  --queries-per-second QUERIES_PER_SECOND
+                        Number of queries per second (default: None)
+  --run-time RUN_TIME   run for at most this many seconds (default: None)
+  --data-file DATA_FILE
+                        File path with the records to send as queries to the server (default: None)
+  --clients CLIENTS     The number of clients to act as (default: 1)
+```
+
+Note that file location passed through --data-file variable is where the records are defined. For example:
+```
+www.google.com A
+www.gmail.com A
+chat.google.com A
+mail.google.com A
+drive.google.com A
+docs.google.com A
+meet.google.com A
+sites.google.com A
+plus.google.com A
+```
+
+### Metrics
+The wrapper runs dnsperf and generates a json document with the results as well as the input configuration/parameters. Benchmark wrapper also wraps around metadata to be indexed into Elasticsearch as explained [here](https://github.com/cloud-bulldozer/benchmark-wrapper#how-do-i-post-results-to-elasticsearch-from-my-wrapper). Here is a sample results document:
+
+```
+{
+    "_index": "snafu-dns_perf-results",
+    "_op_type": "create",
+    "_source": {
+        "uuid": "0f038d28-ef3a-42c0-aea3-435d19686ab1",
+        "cluster_name": "mycluster",
+        "clients": 1,
+        "timestamp": "2021-05-21T16:45:15",
+        "elapsed_time": 6.012354850769043,
+        "latency_stddev": 0.003623,
+        "avg_latency": 0.010767,
+        "latency_min": 0.006275,
+        "latency_max": 0.017417,
+        "QPS": 19.999643,
+        "runtime": 6.000107,
+        "avg_request_packet_size": 32.0,
+        "avg_response_packet_size": 60.0,
+        "queries_lost": 0,
+        "queries_lost_percentage": 0.0,
+        "queries_completed": 120,
+        "queries_completed_percentage": 100.0,
+        "queries_sent": 120,
+        "stop_time_duration": 6.0,
+        "dns_address": "8.8.8.8:53",
+        "dnsperf_version": "2.5.2",
+        "run_id": "NA"
+    },
+    "_id": "18cdda19f6d15c6dab17c6da7fa1422f007057a193b25d298439225c0325ce8f",
+    "run_id": "NA"
+}
+
+```

--- a/snafu/dns_perf_wrapper/dns_perf_wrapper.py
+++ b/snafu/dns_perf_wrapper/dns_perf_wrapper.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+import os
+import argparse
+from .trigger_dns_perf import Trigger_dns_perf
+
+
+class dns_perf_wrapper:
+    def __init__(self, parent_parser):
+        """ Initialize supported arguments """
+
+        parser_object = argparse.ArgumentParser(
+            description="DNS perf workload Wrapper script",
+            parents=[parent_parser],
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        )
+        parser = parser_object.add_argument_group("DNS Perf")
+        parser.add_argument("-u", "--uuid", required=True, help="Provide the uuid")
+        parser.add_argument("--server-address", required=True, help="DNS server address to send the requests")
+        parser.add_argument(
+            "--queries-per-second", required=True, type=int, help="Number of queries per second"
+        )
+        parser.add_argument("--run-time", type=int, required=True, help="run for at most this many seconds")
+        parser.add_argument(
+            "--data-file", required=True, help="File path with the records to send as queries to the server"
+        )
+        parser.add_argument("--clients", default=1, help="The number of clients to act as")
+
+        self.args = parser_object.parse_args()
+
+        self.args.cluster_name = os.getenv("clustername", "mycluster")
+
+    def run(self):
+        yield Trigger_dns_perf(self.args)

--- a/snafu/dns_perf_wrapper/trigger_dns_perf.py
+++ b/snafu/dns_perf_wrapper/trigger_dns_perf.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import time
+import logging
+import subprocess
+from ttp import ttp
+
+logger = logging.getLogger("snafu")
+
+
+class Trigger_dns_perf:
+    def __init__(self, args):
+        """ Initialize the arguments defined """
+
+        self.uuid = args.uuid
+        self.cluster_name = args.cluster_name
+        self.server_address = args.server_address
+        self.queries_per_second = args.queries_per_second
+        self.run_time = args.run_time
+        self.data_file = args.data_file
+        self.clients = args.clients
+
+    def _json_payload(self, data, timestamp, elapsed_time):
+        """ Generates a json payload with the metrics of interest.
+        This is the results document, it gets updated with metrics from the dns-perf run.
+        """
+
+        payload = {
+            "uuid": self.uuid,
+            "cluster_name": self.cluster_name,
+            "clients": self.clients,
+            "timestamp": timestamp,
+            "elapsed_time": elapsed_time,
+        }
+        try:
+            payload.update(data)
+        except Exception as e:
+            logging.error("Failed to update the result document, error: %s" % (e))
+        return payload
+
+    def run(self):
+        """ Runs dns-perf workload and returns the stdout """
+
+        command = "dnsperf -l {} -s {} -Q {} -d {} -c {}".format(
+            self.run_time, self.server_address, self.queries_per_second, self.data_file, self.clients
+        )
+        logger.info(command)
+        out = subprocess.Popen(
+            command, shell=True, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        (output, err) = out.communicate()
+        if out.returncode != 0:
+            logger.error("Failed to run %s, error: %s" % (command, err))
+            exit(1)
+        logger.info("Raw result: \n{}".format(output))
+        return output
+
+    def _parse_stdout(self, stdout):
+        """ Parses the dns-perf run stdout.
+            ttp template to parse the dns-perf stdout.
+        """
+
+        template = """
+DNS Performance Testing Tool
+Version {{ dnsperf_version }}
+
+[Status] Command line: {{ command }}
+[Status] Sending queries (to {{ dns_address }})
+[Status] Started at: {{ start_timestamp }}
+[Status] Stopping after {{ stop_time_duration | to_float }} seconds
+[Status] Testing complete (time limit)
+
+Statistics:
+
+  Queries sent:         {{ queries_sent | to_int }}
+  Queries completed:    {{ queries_completed | to_int }} ({{ queries_completed_percentage | to_float }}%)
+  Queries lost:         {{ queries_lost | to_int }} ({{ queries_lost_percentage | to_float }}%)
+
+  Response codes:       {{ response_code | to_int }}
+  Average packet size:  request {{ avg_request_packet_size | to_int }}, response {{ avg_response_packet_size | to_int }} # noqa
+  Run time (s):         {{ runtime | to_float }}
+  Queries per second:   {{ QPS | to_float }}
+
+  Average Latency (s):  {{ avg_latency | to_float }} (min {{ latency_min | to_float }}, max {{latency_max | to_float }}) # noqa
+  Latency StdDev (s):   {{ latency_stddev | to_float }}
+        """
+        parser = ttp(stdout, template)
+        try:
+            parser.parse()
+        except Exception as e:
+            logger.error("Failed to parse dns-perf sdout, error: %s" % (e))
+            exit(1)
+        parsed_results = parser.result()[0][0]
+        logger.info("Parsed results:")
+        logger.info(parsed_results)
+        return parsed_results
+
+    def emit_actions(self):
+        logger.info("Running dnsperf workload")
+        timestamp = time.strftime("%Y-%m-%dT%H:%M:%S")
+        start_time = time.time()
+        out = self.run()
+        end_time = time.time()
+        elapsed_time = end_time - start_time
+        logger.info("Elapsed time in seconds: {}".format(elapsed_time))
+        logger.info("Starting output parsing")
+        try:
+            data = self._parse_stdout(str(out))
+            result_document = self._json_payload(data, timestamp, elapsed_time)
+            yield result_document, "results"
+        except Exception as e:
+            logger.error("Failed to generate results document, error: %s" % (e))
+            exit(1)
+        logger.info("Successfully finished running dns-perf workload")

--- a/snafu/utils/wrapper_factory.py
+++ b/snafu/utils/wrapper_factory.py
@@ -17,6 +17,7 @@ from snafu.flent_wrapper.flent_wrapper import flent_wrapper
 from snafu.log_generator_wrapper.log_generator_wrapper import log_generator_wrapper
 from snafu.image_pull_wrapper.image_pull_wrapper import image_pull_wrapper
 from snafu.sysbench.sysbench_wrapper import sysbench_wrapper
+from snafu.dns_perf_wrapper.dns_perf_wrapper import dns_perf_wrapper
 
 import logging
 
@@ -42,6 +43,7 @@ wrapper_dict = {
     "log_generator": log_generator_wrapper,
     "image_pull": image_pull_wrapper,
     "sysbench": sysbench_wrapper,
+    "dns_perf": dns_perf_wrapper,
 }
 
 


### PR DESCRIPTION
### Description
This commit adds a wrapper to run dns-perf which sends queries to
the specified DNS server given a profile with the records in order
to test the DNS performance. It parses the results and generated a
 json payload which can be indexed into Elasticsearch to help with
 the analysis.

