### PR TITLE
fix ceph cachedrop URL and env. var. name

### DIFF
--- a/snafu/utils/request_cache_drop.py
+++ b/snafu/utils/request_cache_drop.py
@@ -41,7 +41,7 @@ cache_reload_time = int(os.getenv("CACHE_RELOAD_TIME", default=10))
 
 
 def drop_cache():
-    ceph_cache_drop_pod_ip = os.getenv("ceph_drop_pod_ip")
+    ceph_cache_drop_pod_ip = os.getenv("ceph_osd_cache_drop_pod_ip")
     if ceph_cache_drop_pod_ip is not None:
         logger.info("ceph OSD cache drop pod: %s" % str(ceph_cache_drop_pod_ip))
         conn = http.client.HTTPConnection(
@@ -49,8 +49,8 @@ def drop_cache():
         )
         if http_debug_level > 0:
             conn.set_debuglevel(http_debug_level)
-        logger.info("requesting ceph to drop cache via %s:%d" % (ceph_cache_drop_pod_ip, dropCephCachePort))
-        conn.request("GET", "/DropCephCache")
+        logger.info("requesting ceph to drop OSD cache via %s:%d" % (ceph_cache_drop_pod_ip, dropCephCachePort))
+        conn.request("GET", "/DropOSDCache")
         rsp = conn.getresponse()
         if rsp.status != http.client.OK:
             logger.error("HTTP ERROR %d: %s" % (rsp.status, rsp.reason))

--- a/snafu/utils/request_cache_drop.py
+++ b/snafu/utils/request_cache_drop.py
@@ -43,41 +43,54 @@ cache_reload_time = int(os.getenv("CACHE_RELOAD_TIME", default=10))
 def drop_cache():
     ceph_cache_drop_pod_ip = os.getenv("ceph_osd_cache_drop_pod_ip")
     if ceph_cache_drop_pod_ip is not None:
-        logger.info("ceph OSD cache drop pod: %s" % str(ceph_cache_drop_pod_ip))
+        logger.info("ceph OSD cache drop pod: %s" %
+                    str(ceph_cache_drop_pod_ip))
         conn = http.client.HTTPConnection(
-            ceph_cache_drop_pod_ip, port=dropCephCachePort, timeout=http_timeout
+            ceph_cache_drop_pod_ip,
+            port=dropCephCachePort,
+            timeout=http_timeout
         )
         if http_debug_level > 0:
             conn.set_debuglevel(http_debug_level)
-        logger.info("requesting ceph to drop OSD cache via %s:%d" % (ceph_cache_drop_pod_ip, dropCephCachePort))
+        logger.info("requesting ceph to drop OSD cache via %s:%d" %
+                    (ceph_cache_drop_pod_ip, dropCephCachePort))
         conn.request("GET", "/DropOSDCache")
         rsp = conn.getresponse()
         if rsp.status != http.client.OK:
             logger.error("HTTP ERROR %d: %s" % (rsp.status, rsp.reason))
             raise RunSnafuCacheDropException(
-                "Ceph OSD cache drop %s:%d" % (ceph_cache_drop_pod_ip, dropCephCachePort)
+                "Ceph OSD cache drop %s:%d" %
+                (ceph_cache_drop_pod_ip, dropCephCachePort)
             )
 
     # drop kernel cache if requested to
 
     kernel_cache_drop_pod_ips = os.getenv("kcache_drop_pod_ips")
-    if kernel_cache_drop_pod_ips is not None and kernel_cache_drop_pod_ips.strip() != "":
-        logger.info("kernel cache drop pods: %s" % str(kernel_cache_drop_pod_ips))
+    if kernel_cache_drop_pod_ips is not None and \
+       kernel_cache_drop_pod_ips.strip() != "":
+        logger.info("kernel cache drop pods: %s" %
+                    str(kernel_cache_drop_pod_ips))
         logger.info(
             "debug lvl %d, cachedrop timeout %d, cache reload time %d"
             % (http_debug_level, http_timeout, cache_reload_time)
         )
         pod_ip_list = kernel_cache_drop_pod_ips.split()
         for ip in pod_ip_list:
-            conn = http.client.HTTPConnection(ip, port=dropKernelCachePort, timeout=http_timeout)
+            conn = http.client.HTTPConnection(
+                    ip,
+                    port=dropKernelCachePort,
+                    timeout=http_timeout
+            )
             if http_debug_level > 0:
                 conn.set_debuglevel(http_debug_level)
-            logger.info("requesting kernel to drop cache via %s:%d" % (ip, dropKernelCachePort))
+            logger.info("requesting kernel to drop cache via %s:%d" %
+                        (ip, dropKernelCachePort))
             conn.request("GET", "/DropKernelCache")
             rsp = conn.getresponse()
             if rsp.status != http.client.OK:
                 logger.error("HTTP code %d: %s" % (rsp.status, rsp.reason))
-                raise RunSnafuCacheDropException("kernel cache drop %s:%d" % (ip, dropKernelCachePort))
+                raise RunSnafuCacheDropException("kernel cache drop %s:%d" %
+                                                 (ip, dropKernelCachePort))
         # give kernel a chance to reload important cache items
         # before hitting it with a workload
         time.sleep(cache_reload_time)

--- a/snafu/utils/request_cache_drop.py
+++ b/snafu/utils/request_cache_drop.py
@@ -43,54 +43,43 @@ cache_reload_time = int(os.getenv("CACHE_RELOAD_TIME", default=10))
 def drop_cache():
     ceph_cache_drop_pod_ip = os.getenv("ceph_osd_cache_drop_pod_ip")
     if ceph_cache_drop_pod_ip is not None:
-        logger.info("ceph OSD cache drop pod: %s" %
-                    str(ceph_cache_drop_pod_ip))
+        logger.info("ceph OSD cache drop pod: %s" % str(ceph_cache_drop_pod_ip))
         conn = http.client.HTTPConnection(
-            ceph_cache_drop_pod_ip,
-            port=dropCephCachePort,
-            timeout=http_timeout
+            ceph_cache_drop_pod_ip, port=dropCephCachePort, timeout=http_timeout
         )
         if http_debug_level > 0:
             conn.set_debuglevel(http_debug_level)
-        logger.info("requesting ceph to drop OSD cache via %s:%d" %
-                    (ceph_cache_drop_pod_ip, dropCephCachePort))
+        logger.info(
+            "requesting ceph to drop OSD cache via %s:%d" % (ceph_cache_drop_pod_ip, dropCephCachePort)
+        )
         conn.request("GET", "/DropOSDCache")
         rsp = conn.getresponse()
         if rsp.status != http.client.OK:
             logger.error("HTTP ERROR %d: %s" % (rsp.status, rsp.reason))
             raise RunSnafuCacheDropException(
-                "Ceph OSD cache drop %s:%d" %
-                (ceph_cache_drop_pod_ip, dropCephCachePort)
+                "Ceph OSD cache drop %s:%d" % (ceph_cache_drop_pod_ip, dropCephCachePort)
             )
 
     # drop kernel cache if requested to
 
     kernel_cache_drop_pod_ips = os.getenv("kcache_drop_pod_ips")
-    if kernel_cache_drop_pod_ips is not None and \
-       kernel_cache_drop_pod_ips.strip() != "":
-        logger.info("kernel cache drop pods: %s" %
-                    str(kernel_cache_drop_pod_ips))
+    if kernel_cache_drop_pod_ips is not None and kernel_cache_drop_pod_ips.strip() != "":
+        logger.info("kernel cache drop pods: %s" % str(kernel_cache_drop_pod_ips))
         logger.info(
             "debug lvl %d, cachedrop timeout %d, cache reload time %d"
             % (http_debug_level, http_timeout, cache_reload_time)
         )
         pod_ip_list = kernel_cache_drop_pod_ips.split()
         for ip in pod_ip_list:
-            conn = http.client.HTTPConnection(
-                    ip,
-                    port=dropKernelCachePort,
-                    timeout=http_timeout
-            )
+            conn = http.client.HTTPConnection(ip, port=dropKernelCachePort, timeout=http_timeout)
             if http_debug_level > 0:
                 conn.set_debuglevel(http_debug_level)
-            logger.info("requesting kernel to drop cache via %s:%d" %
-                        (ip, dropKernelCachePort))
+            logger.info("requesting kernel to drop cache via %s:%d" % (ip, dropKernelCachePort))
             conn.request("GET", "/DropKernelCache")
             rsp = conn.getresponse()
             if rsp.status != http.client.OK:
                 logger.error("HTTP code %d: %s" % (rsp.status, rsp.reason))
-                raise RunSnafuCacheDropException("kernel cache drop %s:%d" %
-                                                 (ip, dropKernelCachePort))
+                raise RunSnafuCacheDropException("kernel cache drop %s:%d" % (ip, dropKernelCachePort))
         # give kernel a chance to reload important cache items
         # before hitting it with a workload
         time.sleep(cache_reload_time)


### PR DESCRIPTION
### Description

correct the URL used to invoke the cache dropper
use env. var. for cache drop pod that matches benchmark-operator
depends on recently merged [bohica PR 19](https://github.com/cloud-bulldozer/bohica/pull/19)

### Fixes

need to specify Ceph cache dropper pod IP in workload CR.  Now benchmark-operator will get it and pass it to wrapper.