### PR TITLE
Disable SNAFU logging

### DIFF
--- a/snafu/log_generator_wrapper/trigger_log_generator.py
+++ b/snafu/log_generator_wrapper/trigger_log_generator.py
@@ -22,9 +22,12 @@ import boto3
 import json
 import subprocess
 import uuid
+import os
 from kafka import KafkaConsumer, TopicPartition
 
 logger = logging.getLogger("snafu")
+if (os.getenv("snafu_disable_logs", "False")) == "True":
+    logger.disabled = True
 
 
 class Trigger_log_generator:


### PR DESCRIPTION
This is a corner case needed during our log testing.
To accurately count the number of synthetic log messages
generated by the log generator pod, we want to disable the regular SNAFU
logging. This will make it harder to debug, but this is only something
a user optionally sets in the benchmark-operator CR. The reason we want
to do this is, we plan to deploy only the log-generator pods to a separate
namespace and forward those logs to a separate kafka topic and then we can
reliably read off the offset in the topic without reading each message to
verify that all log messages generated by the log generator pod made it to kafka.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

### Description

### Fixes
