### PR TITLE
Correct license in setup.cfg (mit -> apache2)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ name = snafu
 description = To store benchmark results in elasticsearch for long term investigations.
 author = red-hat-performance
 author-email = perf-dept@redhat.com
-license = mit
+license = Apache License 2.0
 long-description = file: README.md
 long-description-content-type = text/markdown; charset=UTF-8
 classifiers =


### PR DESCRIPTION
### Description

Correct the license declared in setup.cfg. Was set to MIT when it should be set to Apache 2.0

For reference, set the license string by example from https://github.com/apache/airflow/blob/main/setup.cfg, which also uses Apache 2.0
