### PR TITLE
[FIO] Per OSD Metric Query Updates

### DIFF
--- a/snafu/utils/prometheus_labels/fio_included_labels.json
+++ b/snafu/utils/prometheus_labels/fio_included_labels.json
@@ -42,11 +42,11 @@
     },
     "Ceph_Per_OSD_Throughput_Read": {
         "label": "ceph_osd_op_r_out_bytes",
-        "query": "irate(ceph_osd_op_r_out_bytes[1m]) "
+        "query": "rate(ceph_osd_op_r_out_bytes[65s]) "
     },
     "Ceph_Per_OSD_Throughput_Write": {
         "label": "ceph_osd_op_w_in_bytes",
-        "query": "irate(ceph_osd_op_w_in_bytes[1m]) "
+        "query": "rate(ceph_osd_op_w_in_bytes[65s]) "
     },
     "Ceph_Per_OSD_Throughput_Read-Modify-Write_in": {
         "label": "ceph_osd_op_rw_in_bytes",


### PR DESCRIPTION
### Description
This PR updates the Prometheus queries for OSD read/write used in the FIO benchmark to ensure consistent data is delivered.

### Fixes
#### `irate` to `rate`
`irate` has been changed to `rate`, as with `irate` graphs like the following are possible:
![image](https://user-images.githubusercontent.com/10466117/124186278-1655dd00-da8a-11eb-9f87-f265474710e2.png)

This has caused tests where the throughput of all OSDs were reported as 0 Bytes/secs, regardless of the test being performed.

The reason for this is that [`irate`](https://prometheus.io/docs/prometheus/latest/querying/functions/#irate) looks at the latest 2 data points and [`rate`](https://prometheus.io/docs/prometheus/latest/querying/functions/#rate) looks at the entire range.


#### 65 Second interval
The interval has been extended to 65 seconds to avoid a sampling issue.  Based off my tests, there is a 15 second refresh interval for `ceph_osd_op_*_bytes` (see below):
![image](https://user-images.githubusercontent.com/10466117/124186592-8a908080-da8a-11eb-9315-4709bc0f52f2.png)

A 65 second interval was chosen to ensure that 4 refreshes were always captured.

An example of the graph the Prometheus query creates is below:
![image](https://user-images.githubusercontent.com/10466117/124186679-abf16c80-da8a-11eb-8e02-43fb684544d5.png)
