### PR TITLE
enable prometheus data collection for uperf workload

### DIFF
--- a/snafu/uperf_wrapper/trigger_uperf.py
+++ b/snafu/uperf_wrapper/trigger_uperf.py
@@ -44,6 +44,7 @@ class Trigger_uperf:
         self.density_range = args.density_range
         self.node_range = args.node_range
         self.pod_id = args.pod_id
+        self.prom_es = args.prom_es
 
     def _json_payload(self, results, data, sample):
         processed = []
@@ -120,6 +121,10 @@ class Trigger_uperf:
                 "read_message_size": int(rsize),
                 "num_threads": int(nthr),
                 "duration": len(results),
+                "tool": "uperf",
+                "test_config": "uperf",
+                "starttime": float(results[0][0]) / 1000,
+                "endtime": float(results[-1][0]) / 1000,
             },
         )
 
@@ -144,7 +149,10 @@ class Trigger_uperf:
             documents = self._json_payload(results, data, s)
             if len(documents) > 0:
                 for document in documents:
-                    yield document, "results"
+                    if self.prom_es == "":
+                        yield document, "results"
+                    else:
+                        yield document, "get_prometheus_trigger"
             logger.info(data)
             logger.info(stdout)
             logger.info("Finished executing sample %d out of %d" % (s, self.sample))

--- a/snafu/uperf_wrapper/uperf_wrapper.py
+++ b/snafu/uperf_wrapper/uperf_wrapper.py
@@ -60,6 +60,7 @@ class uperf_wrapper:
         # each node will run with density number of pods, this is the 0 based
         # number of that pod, useful for displaying throughput of each density
         self.args.pod_id = os.getenv("my_pod_idx", "")
+        self.args.prom_es = os.getenv("prom_es", "")
 
     def run(self):
         uperf_wrapper_obj = Trigger_uperf(self.args)

--- a/snafu/utils/prometheus_labels/uperf_included_labels.json
+++ b/snafu/utils/prometheus_labels/uperf_included_labels.json
@@ -1,0 +1,8 @@
+{
+    "data": {
+        "Average_CPU_Usage_per_Instance": {
+            "label": "node_cpu_seconds_total",
+            "query": "(sum by (instance, mode)(rate(node_cpu_seconds_total{mode='idle'}[1m])))"
+        }
+    }
+}


### PR DESCRIPTION
### Description
This change will let user to enable prometheus metric collection and forward to elasticsearch for uperf workoads, just only collects CPU metrics at present.

### Fixes
