### PR TITLE
Proper parsing for uperf connect type workload

### DIFF
--- a/snafu/uperf_wrapper/trigger_uperf.py
+++ b/snafu/uperf_wrapper/trigger_uperf.py
@@ -109,7 +109,10 @@ class Trigger_uperf:
         # This will yeild us this structure :
         #     timestamp, number of bytes, number of operations
         # [('1559581000962.0330', '0', '0'), ('1559581001962.8459', '4697358336', '286704') ]
-        results = re.findall(r"timestamp_ms:(.*) name:Txn2 nr_bytes:(.*) nr_ops:(.*)", stdout)
+        if test_type == 'connect':
+            results = re.findall(r"timestamp_ms:(.*) name:Txn1 nr_bytes:(.*) nr_ops:(.*)", stdout)
+        else:
+            results = re.findall(r"timestamp_ms:(.*) name:Txn2 nr_bytes:(.*) nr_ops:(.*)", stdout)
         # We assume message_size=write_message_size to prevent breaking dependant implementations
         return (
             results,

--- a/snafu/uperf_wrapper/trigger_uperf.py
+++ b/snafu/uperf_wrapper/trigger_uperf.py
@@ -109,7 +109,7 @@ class Trigger_uperf:
         # This will yeild us this structure :
         #     timestamp, number of bytes, number of operations
         # [('1559581000962.0330', '0', '0'), ('1559581001962.8459', '4697358336', '286704') ]
-        if test_type == 'connect':
+        if test_type == "connect":
             results = re.findall(r"timestamp_ms:(.*) name:Txn1 nr_bytes:(.*) nr_ops:(.*)", stdout)
         else:
             results = re.findall(r"timestamp_ms:(.*) name:Txn2 nr_bytes:(.*) nr_ops:(.*)", stdout)


### PR DESCRIPTION
### Description
uperf connect type workloads do not use the `Txn2` output, only `Txn1`
### Fixes
