### PR TITLE
Bump es version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ zip_safe = False
 packages = find:
 include_package_data = True
 # Add here dependencies of your project (semicolon/line-separated), e.g.
-install_requires = dataclasses; configargparse; configparser; elasticsearch>=6.0.0,<=7.0.2; statistics; numpy; pyyaml; requests; redis; python-dateutil>=2.7.3; prometheus_api_client; scipy; openshift==0.11; kubernetes==11; setuptools>=40.3.0; boto3; flent; importlib_metadata; kafka-python; ttp
+install_requires = dataclasses; configargparse; configparser; elasticsearch>=7.0.0,<8.0.0; statistics; numpy; pyyaml; requests; redis; python-dateutil>=2.7.3; prometheus_api_client; scipy; openshift==0.11; kubernetes==11; setuptools>=40.3.0; boto3; flent; importlib_metadata; kafka-python; ttp
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.6

--- a/snafu/utils/py_es_bulk.py
+++ b/snafu/utils/py_es_bulk.py
@@ -12,14 +12,9 @@ import math
 from random import SystemRandom
 from collections import Counter, deque
 
-try:
-    from elasticsearch1 import VERSION as es_VERSION, helpers, exceptions as es_excs
+from elasticsearch import VERSION as es_VERSION, helpers, exceptions as es_excs
 
-    _es_logger = "elasticsearch1"
-except ImportError:
-    from elasticsearch import VERSION as es_VERSION, helpers, exceptions as es_excs
-
-    _es_logger = "elasticsearch"
+_es_logger = "elasticsearch"
 
 logger = logging.getLogger("snafu")
 logger.debug("elasticsearch module version: %d.%d.%d" % es_VERSION)


### PR DESCRIPTION
### Description

This PR bumps elasticsearch client version within our ``setup.cfg`` to use ``elasticsearch>=7.0.0,<8.0.0``, (as per documentation spec at https://elasticsearch-py.readthedocs.io/en/v7.14.0a1/), in order to enable Python 3.9 support.  Joe and I discussed that we would need to test this change against our ES instances to make sure bumping the client version doesn't break our data ingest.

### Fixes

Currently we have elasticsearch client pinned as ``elasticsearch>=6.0.0,<=7.0.2``, however these versions are not compatible with Python 3.9. The following ``ImportError`` is observed when trying to invoke snafu on Python 3.9:

```
snafu/run_snafu.py:20: in <module>
    import elasticsearch
.tox/py39/lib/python3.9/site-packages/elasticsearch/__init__.py:24: in <module>
    from .client import Elasticsearch
.tox/py39/lib/python3.9/site-packages/elasticsearch/client/__init__.py:4: in <module>
    from ..transport import Transport
.tox/py39/lib/python3.9/site-packages/elasticsearch/transport.py:4: in <module>
    from .connection import Urllib3HttpConnection
.tox/py39/lib/python3.9/site-packages/elasticsearch/connection/__init__.py:2: in <module>
    from .http_requests import RequestsHttpConnection
.tox/py39/lib/python3.9/site-packages/elasticsearch/connection/http_requests.py:3: in <module>
    from base64 import decodestring
E   ImportError: cannot import name 'decodestring' from 'base64' (/opt/hostedtoolcache/Python/3.9.6/x64/lib/python3.9/base64.py)
```

Additionally, I removed the ``elasticsearch1`` module import, as we only have ES >= 7 in our environment, which is supported within the given ``elasticsearch`` module itself.

