### PR TITLE
Change linpack URL to latest Intel bits, change LINPACK_DAT so no need to be root

### DIFF
--- a/snafu/linpack_wrapper/Dockerfile
+++ b/snafu/linpack_wrapper/Dockerfile
@@ -6,5 +6,5 @@ RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/
 RUN pip3 install -e /opt/snafu/
 
-RUN curl https://software.intel.com/sites/default/files/managed/cc/19/l_mklb_p_2019.6.005.tgz --output linpack.tgz
+RUN curl https://software.intel.com/content/dam/develop/external/us/en/documents/l_onemklbench_p_2021.2.0_109.tgz --output linpack.tgz
 RUN tar xzvf linpack.tgz -C /opt

--- a/snafu/linpack_wrapper/linpack.sh
+++ b/snafu/linpack_wrapper/linpack.sh
@@ -7,9 +7,9 @@ if [ "$#" -ne 4 ]; then
 fi
 
 # Location of Linpack binary
-LINPACK='/opt/l_mklb_p_2019.6.005/benchmarks_2019/linux/mkl/benchmarks/linpack/xlinpack_xeon64'
+LINPACK='/opt/benchmarks_2021.2.0/linux/mkl/benchmarks/linpack/xlinpack_xeon64'
 
-LINPACK_DAT='/opt/linpack.dat'
+LINPACK_DAT='/tmp/linpack.dat'
 
 NUM_CPU=`cat /proc/cpuinfo | grep processor | wc -l`
 export OMP_NUM_THREADS=$NUM_CPU


### PR DESCRIPTION
### Description

Move to 2021 version of Intel linpack

### Fixes

- Updated linpack URL, old URL is no longer reachable
- Also changed LINPACK_DAT to be in /tmp instead of /opt, so it will run on openshift without needing a privileged pod
- Interface remains unchanged
