### PR TITLE
Fix sysbench's Dockerfile

### DIFF
--- a/snafu/sysbench/Dockerfile
+++ b/snafu/sysbench/Dockerfile
@@ -7,5 +7,6 @@ RUN dnf install -y --nodocs sysbench && dnf clean all
 RUN dnf install -y --nodocs python3-pip procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
 RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY . /opt/snafu
+RUN pip3 install --upgrade # benchmark-wrapper fails to install otherwise
 RUN pip3 install -e /opt/snafu/
 

--- a/snafu/sysbench/Dockerfile
+++ b/snafu/sysbench/Dockerfile
@@ -9,4 +9,3 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY . /opt/snafu
 RUN pip3 install --upgrade # benchmark-wrapper fails to install otherwise
 RUN pip3 install -e /opt/snafu/
-

--- a/snafu/sysbench/Dockerfile
+++ b/snafu/sysbench/Dockerfile
@@ -2,5 +2,10 @@ FROM registry.access.redhat.com/ubi8:latest
 MAINTAINER Sai Sindhur Malleni <smalleni@redhat.org>
 
 RUN dnf install -y --nodocs https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-RUN dnf install -y --nodocs sysbench
-RUN dnf install -y --nodocs procps-ng iproute net-tools ethtool nmap iputils
+RUN dnf install -y --nodocs sysbench && dnf clean all
+
+RUN dnf install -y --nodocs python3-pip procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
+RUN ln -s /usr/bin/python3 /usr/bin/python
+COPY . /opt/snafu
+RUN pip3 install -e /opt/snafu/
+


### PR DESCRIPTION
### Description

The Dockerfile for sysbench was missing benchmark-wrapper and wouldn't build for AARCH64.

### Fixes

- Install benchmark-wrapper in sysbench's Dockerfile
- Update pip3 inside the container so it will build on a Raspberry PI4
