### PR TITLE
Fix sysbench path

### DIFF
--- a/snafu/sysbench/trigger_sysbench.py
+++ b/snafu/sysbench/trigger_sysbench.py
@@ -43,7 +43,7 @@ class trigger_sysbench:
         #  open config file
         config_file = open(self.sysbench_file, "r")
 
-        cmd = "/bin/sysbench"
+        cmd = "/usr/bin/sysbench"
         #  for each option add it to the command line
         for option in config_file:
             option = option.strip()


### PR DESCRIPTION
### Description

On Ubuntu, sysbench only exists on `/usr/bin`, on CentOS 8 it is in both `/bin/` and `/usr/bin`

### Fixes

- Look for sysbench in `/usr/bin/sysbench`
