### PR TITLE
Downgrade elasticsearch-py version due to incompatibility issues

### DIFF
--- a/ci/common.sh
+++ b/ci/common.sh
@@ -34,7 +34,7 @@ function update_operator_image() {
   sed -i "s#${default_ripsaw_image_prefix}/stressng:latest#${SNAFU_WRAPPER_IMAGE_PREFIX}/stressng:${SNAFU_IMAGE_TAG}#g" roles/stressng/templates/*
   sed -i "s#${default_ripsaw_image_prefix}/flent:latest#${SNAFU_WRAPPER_IMAGE_PREFIX}/flent:${SNAFU_IMAGE_TAG}#g" roles/flent/templates/*
   image_spec=$image_location/$image_account/benchmark-operator:$SNAFU_IMAGE_TAG
-  make podman-build podman-push deploy IMG=$image_spec
+  make image-build image-push deploy IMG=$image_spec
   kubectl wait --for=condition=available "deployment/benchmark-controller-manager" -n benchmark-operator --timeout=300s
 
   # In case we have issues uploading to quay we will retry a few times

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ zip_safe = False
 packages = find:
 include_package_data = True
 # Add here dependencies of your project (semicolon/line-separated), e.g.
-install_requires = dataclasses; configargparse; configparser; elasticsearch>=7.0.0,<8.0.0; statistics; numpy; pyyaml; requests; redis; python-dateutil>=2.7.3; prometheus_api_client; scipy; openshift==0.11; kubernetes==11; setuptools>=40.3.0; boto3; flent; importlib_metadata; kafka-python; ttp
+install_requires = dataclasses; configargparse; configparser; elasticsearch>=7.0.0,<7.14.0; statistics; numpy; pyyaml; requests; redis; python-dateutil>=2.7.3; prometheus_api_client; scipy; openshift==0.11; kubernetes==11; setuptools>=40.3.0; boto3; flent; importlib_metadata; kafka-python; ttp
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.6


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

It seems like elasticsearch-py is not supporting anymore ES "forks" like the AWS one starting from the version 7.14
Some context:

https://github.com/elastic/elasticsearch-py/blob/master/docs/guide/release-notes.asciidoc#7140-2021-08-02
https://github.com/elastic/elasticsearch-py/issues/1639#issuecomment-883319286

### Fixes
Fixes ES indexing in all workloads
```python
>>> es=elasticsearch.Elasticsearch("https://foo:bar@search-perfscale-pro-asdfasdfasdf.us-west-2.es.amazonaws.com")
>>> es.ping()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.6/site-packages/elasticsearch/client/utils.py", line 168, in _wrapped
    return func(*args, params=params, headers=headers, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/elasticsearch/client/__init__.py", line 282, in ping
    "HEAD", "/", params=params, headers=headers
  File "/usr/local/lib/python3.6/site-packages/elasticsearch/transport.py", line 413, in perform_request
    _ProductChecker.raise_error(self._verified_elasticsearch)
  File "/usr/local/lib/python3.6/site-packages/elasticsearch/transport.py", line 630, in raise_error
    raise UnsupportedProductError(message)
elasticsearch.exceptions.UnsupportedProductError: The client noticed that the server is not a supported distribution of Elasticsearch
```