### PR TITLE
fix sysbench docker for aarch64

### DIFF
--- a/snafu/sysbench/Dockerfile
+++ b/snafu/sysbench/Dockerfile
@@ -4,8 +4,8 @@ MAINTAINER Sai Sindhur Malleni <smalleni@redhat.org>
 RUN dnf install -y --nodocs https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 RUN dnf install -y --nodocs sysbench && dnf clean all
 
-RUN dnf install -y --nodocs python3-pip procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
+RUN dnf install -y --nodocs python3.8 procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
 RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY . /opt/snafu
-RUN pip3 install --upgrade # benchmark-wrapper fails to install otherwise
+RUN pip3 install --upgrade pip # benchmark-wrapper fails to install otherwise
 RUN pip3 install -e /opt/snafu/


### PR DESCRIPTION
### Description

2nd round of fixes to get Docker image building on a Raspberry PI 4.

### Fixes

- Was missing `pip` when I did #309 for the upgrade
- Failed to install benchmark-wrapper since it requires at least Python 3.7
