### PR TITLE
upgrade comparison patch

### DIFF
--- a/snafu/upgrade_openshift_wrapper/trigger_upgrade.py
+++ b/snafu/upgrade_openshift_wrapper/trigger_upgrade.py
@@ -116,7 +116,15 @@ class Trigger_upgrade:
             the_time = datetime.datetime.strptime(
                 clusterversion.get().attributes.items[0].status.history[0].completionTime, time_format
             )
-            return init_version, desired_version, platform, the_time, the_time, (the_time - the_time)
+            return (
+                init_version,
+                desired_version,
+                desired_version,
+                platform,
+                the_time,
+                the_time,
+                (the_time - the_time),
+            )
 
         c_state = "incomplete"
         c_version = "0.0.0"
@@ -161,7 +169,7 @@ class Trigger_upgrade:
         total_time = end_time - start_time
         logger.info("Total upgrade time: %s" % total_time)
 
-        return init_version, new_version, platform, start_time, end_time, total_time
+        return init_version, desired_version, new_version, platform, start_time, end_time, total_time
 
     def get_timings(self):
         logger.info("Getting timing stats from cluster Operators")
@@ -199,6 +207,7 @@ class Trigger_upgrade:
         self.timestamp = time.strftime("%Y-%m-%dT%H:%M:%S")
         (
             self.init_version,
+            self.desired_version,
             self.end_version,
             self.platform,
             self.start_time,
@@ -218,10 +227,12 @@ class Trigger_upgrade:
         docs.append(self._json_payload(data))
         for item in docs:
             yield item, ""
-        if self.end_version != desired_version:
+        if self.end_version != self.desired_version:
             logger.error("Cluster did not upgrade to desired version")
             logger.error(
-                "Cluster version is {} and desired version is {}".format(self.end_version, desired_version)
+                "Cluster version is {} and desired version is {}".format(
+                    self.end_version, self.desired_version
+                )
             )
             exit(1)
-        logger.info("Finished upgrading the cluster to version %s" % (desired_version))
+        logger.info("Finished upgrading the cluster to version %s" % (self.desired_version))


### PR DESCRIPTION
### Description
[This](https://github.com/cloud-bulldozer/benchmark-wrapper/blob/master/snafu/upgrade_openshift_wrapper/trigger_upgrade.py#L218) validation is not right, `desired_version` variable from [here](https://github.com/cloud-bulldozer/benchmark-wrapper/blob/master/snafu/upgrade_openshift_wrapper/trigger_upgrade.py#L191) has got the old version prior to upgrade and validating with that cause the script to fail even after a successful upgrade. Instead it should compare with version post upgrade command. 

```
2021-08-09T19:53:48Z - INFO     - MainProcess - trigger_upgrade: Cluster upgrade complete
...
2021-08-09T19:53:48Z - ERROR    - MainProcess - trigger_upgrade: Cluster did not upgrade to desired version
2021-08-09T19:53:48Z - ERROR    - MainProcess - trigger_upgrade: Cluster version is 4.7.16 and desired version is 4.7.13
```
Updated the var scope fixes it, 
```
2021-08-10T18:04:19Z - INFO     - MainProcess - trigger_upgrade: Finished upgrading the cluster to version 4.7.13
```


### Fixes
