### PR TITLE
Stressng: add Elasticsearch fields for visualization

### DIFF
--- a/snafu/stressng_wrapper/stressng_wrapper.py
+++ b/snafu/stressng_wrapper/stressng_wrapper.py
@@ -30,6 +30,7 @@ class stressng_wrapper:
         self.args.es_rhcos_version = ""
         self.args.es_kata_version = ""
         self.args.es_kind = ""
+        self.args.es_build_version = ""
         self.args.es_data = ""
 
         if "runtype" in os.environ:
@@ -55,6 +56,8 @@ class stressng_wrapper:
             self.args.es_kata_version = os.environ["es_kata_version"]
         if "es_kind" in os.environ:
             self.args.es_kind = os.environ["es_kind"]
+        if "es_build_version" in os.environ:
+            self.args.es_build_version = os.environ["es_build_version"]
         if "es_data" in os.environ:
             self.args.es_data = os.environ["es_data"]
 

--- a/snafu/stressng_wrapper/stressng_wrapper.py
+++ b/snafu/stressng_wrapper/stressng_wrapper.py
@@ -23,6 +23,14 @@ class stressng_wrapper:
         self.args.vm_stressors = ""
         self.args.vm_bytes = ""
         self.args.mem_stressors = ""
+        # es custom fields
+        self.args.es_ocp_version = ""
+        self.args.es_cnv_version = ""
+        self.args.es_vm_os_version = ""
+        self.args.es_rhcos_version = ""
+        self.args.es_kata_version = ""
+        self.args.es_kind = ""
+        self.args.es_data = ""
 
         if "runtype" in os.environ:
             self.args.runtype = os.environ["runtype"]
@@ -34,6 +42,21 @@ class stressng_wrapper:
             self.args.vm_bytes = os.environ["vm_bytes"]
         if "mem_stressors" in os.environ:
             self.args.mem_stressors = os.environ["mem_stressors"]
+        # es custom fields
+        if "es_ocp_version" in os.environ:
+            self.args.es_ocp_version = os.environ["es_ocp_version"]
+        if "es_cnv_version" in os.environ:
+            self.args.es_cnv_version = os.environ["es_cnv_version"]
+        if "es_vm_os_version" in os.environ:
+            self.args.es_vm_os_version = os.environ["es_vm_os_version"]
+        if "es_rhcos_version" in os.environ:
+            self.args.es_rhcos_version = os.environ["es_rhcos_version"]
+        if "es_kata_version" in os.environ:
+            self.args.es_kata_version = os.environ["es_kata_version"]
+        if "es_kind" in os.environ:
+            self.args.es_kind = os.environ["es_kind"]
+        if "es_data" in os.environ:
+            self.args.es_data = os.environ["es_data"]
 
     def run(self):
         stressng_wrapper_obj = Trigger_stressng(self.args)

--- a/snafu/stressng_wrapper/trigger_stressng.py
+++ b/snafu/stressng_wrapper/trigger_stressng.py
@@ -24,6 +24,7 @@ class Trigger_stressng:
         self.es_rhcos_version = args.es_rhcos_version
         self.es_kata_version = args.es_kata_version
         self.es_kind = args.es_kind
+        self.es_build_version = args.es_build_version
         self.es_data = args.es_data
 
     def _run_stressng(self):
@@ -59,6 +60,7 @@ class Trigger_stressng:
         es_rhcos_version,
         es_kata_version,
         es_kind,
+        es_build_version,
         es_data,
         timestamp,
     ):
@@ -80,6 +82,7 @@ class Trigger_stressng:
                 "es_rhcos_version": es_rhcos_version,
                 "es_kata_version": es_kata_version,
                 "es_kind": es_kind,
+                "es_build_version": es_build_version,
                 "es_data": es_data,
                 "timestamp": timestamp,
             }
@@ -138,6 +141,7 @@ class Trigger_stressng:
             self.es_rhcos_version,
             self.es_kata_version,
             self.es_kind,
+            self.es_build_version,
             self.es_data,
             timestamp,
         )

--- a/snafu/stressng_wrapper/trigger_stressng.py
+++ b/snafu/stressng_wrapper/trigger_stressng.py
@@ -17,6 +17,14 @@ class Trigger_stressng:
         self.vm_bytes = args.vm_bytes
         self.mem_stressors = args.mem_stressors
         self.jobfile = args.jobfile
+        # es customs fields
+        self.es_ocp_version = args.es_ocp_version
+        self.es_cnv_version = args.es_cnv_version
+        self.es_vm_os_version = args.es_vm_os_version
+        self.es_rhcos_version = args.es_rhcos_version
+        self.es_kata_version = args.es_kata_version
+        self.es_kind = args.es_kind
+        self.es_data = args.es_data
 
     def _run_stressng(self):
         cmd = "stress-ng --job {} --log-file stressng.log -Y stressng.yml".format(self.jobfile)
@@ -36,7 +44,7 @@ class Trigger_stressng:
             results.append(result)
         return results
 
-    def _json_payload(self, data, uuid, runtype, timeout, vm_stressors, vm_bytes, mem_stressors, timestamp):
+    def _json_payload(self, data, uuid, runtype, timeout, vm_stressors, vm_bytes, mem_stressors, es_ocp_version, es_cnv_version, es_vm_os_version, es_rhcos_version, es_kata_version, es_kind, es_data, timestamp):
         logger.info("generating json payload")
         edict = {}
         processed = []
@@ -49,6 +57,13 @@ class Trigger_stressng:
                 "vm_stressors": vm_stressors,
                 "vm_bytes": vm_bytes,
                 "mem_stressors": mem_stressors,
+                "es_ocp_version": es_ocp_version,
+                "es_cnv_version": es_cnv_version,
+                "es_vm_os_version": es_vm_os_version,
+                "es_rhcos_version": es_rhcos_version,
+                "es_kata_version": es_kata_version,
+                "es_kind": es_kind,
+                "es_data": es_data,
                 "timestamp": timestamp,
             }
         )
@@ -100,6 +115,13 @@ class Trigger_stressng:
             self.vm_stressors,
             self.vm_bytes,
             self.mem_stressors,
+            self.es_ocp_version,
+            self.es_cnv_version,
+            self.es_vm_os_version,
+            self.es_rhcos_version,
+            self.es_kata_version,
+            self.es_kind,
+            self.es_data,
             timestamp,
         )
         if len(documents) > 0:

--- a/snafu/stressng_wrapper/trigger_stressng.py
+++ b/snafu/stressng_wrapper/trigger_stressng.py
@@ -44,15 +44,45 @@ class Trigger_stressng:
             results.append(result)
         return results
 
-    def _json_payload(self, data, uuid, runtype, timeout, vm_stressors, vm_bytes, mem_stressors, es_ocp_version, es_cnv_version, es_vm_os_version, es_rhcos_version, es_kata_version, es_kind, es_data, timestamp):
+    def _json_payload(
+        self,
+        data,
+        uuid,
+        runtype,
+        timeout,
+        vm_stressors,
+        vm_bytes,
+        mem_stressors,
+        es_ocp_version,
+        es_cnv_version,
+        es_vm_os_version,
+        es_rhcos_version,
+        es_kata_version,
+        es_kind,
+        es_data,
+        timestamp
+    ):
         logger.info("generating json payload")
         edict = {}
         processed = []
         edict.update(
-            dict(workload="stressng", uuid=uuid, runtype=runtype, timeout=timeout, vm_stressors=vm_stressors,
-                 vm_bytes=vm_bytes, mem_stressors=mem_stressors, es_ocp_version=es_ocp_version,
-                 es_cnv_version=es_cnv_version, es_vm_os_version=es_vm_os_version, es_rhcos_version=es_rhcos_version,
-                 es_kata_version=es_kata_version, es_kind=es_kind, es_data=es_data, timestamp=timestamp)
+            {
+                "workload": "stressng",
+                "uuid": uuid,
+                "runtype": runtype,
+                "timeout": timeout,
+                "vm_stressors": vm_stressors,
+                "vm_bytes": vm_bytes,
+                "mem_stressors": mem_stressors,
+                "es_ocp_version": es_ocp_version,
+                "es_cnv_version": es_cnv_version,
+                "es_vm_os_version": es_vm_os_version,
+                "es_rhcos_version": es_rhcos_version,
+                "es_kata_version": es_kata_version,
+                "es_kind": es_kind,
+                "es_data": es_data,
+                "timestamp": timestamp,
+            }
         )
         for i in range(len(data)):
             edict.update(dict(data[i]))

--- a/snafu/stressng_wrapper/trigger_stressng.py
+++ b/snafu/stressng_wrapper/trigger_stressng.py
@@ -49,23 +49,10 @@ class Trigger_stressng:
         edict = {}
         processed = []
         edict.update(
-            {
-                "workload": "stressng",
-                "uuid": uuid,
-                "runtype": runtype,
-                "timeout": timeout,
-                "vm_stressors": vm_stressors,
-                "vm_bytes": vm_bytes,
-                "mem_stressors": mem_stressors,
-                "es_ocp_version": es_ocp_version,
-                "es_cnv_version": es_cnv_version,
-                "es_vm_os_version": es_vm_os_version,
-                "es_rhcos_version": es_rhcos_version,
-                "es_kata_version": es_kata_version,
-                "es_kind": es_kind,
-                "es_data": es_data,
-                "timestamp": timestamp,
-            }
+            dict(workload="stressng", uuid=uuid, runtype=runtype, timeout=timeout, vm_stressors=vm_stressors,
+                 vm_bytes=vm_bytes, mem_stressors=mem_stressors, es_ocp_version=es_ocp_version,
+                 es_cnv_version=es_cnv_version, es_vm_os_version=es_vm_os_version, es_rhcos_version=es_rhcos_version,
+                 es_kata_version=es_kata_version, es_kind=es_kind, es_data=es_data, timestamp=timestamp)
         )
         for i in range(len(data)):
             edict.update(dict(data[i]))

--- a/snafu/stressng_wrapper/trigger_stressng.py
+++ b/snafu/stressng_wrapper/trigger_stressng.py
@@ -60,7 +60,7 @@ class Trigger_stressng:
         es_kata_version,
         es_kind,
         es_data,
-        timestamp
+        timestamp,
     ):
         logger.info("generating json payload")
         edict = {}


### PR DESCRIPTION
### Description
Stressng: Adding ElasticSearch fields for visualization ( This PR is depend on the same benchmark-operator PR https://github.com/cloud-bulldozer/benchmark-operator/pull/641 )
### Fixes
Adding the following elasticsearch fields:
es_ocp_version
es_cnv_version
es_vm_os_version
es_rhcos_version
es_kata_version
es_kind
es_data