### PR TITLE
common code for redis pod synchronization

### DIFF
--- a/snafu/smallfile_wrapper/trigger_smallfile.py
+++ b/snafu/smallfile_wrapper/trigger_smallfile.py
@@ -69,17 +69,14 @@ class _trigger_smallfile:
                     os.unlink(os.path.join(rsptime_dir, c))
 
         if self.clients > 1 and self.redis_host:
-            channel = 'smallfile-%s-sample-%d-op-%s-before' % (
-                        self.uuid, self.sample, self.operation)
-            redis_sync_pods(self.clients, 2 * http_timeout, self.redis_host,
-                            channel, self.logger)
+            channel = "smallfile-%s-sample-%d-op-%s-before" % (self.uuid, self.sample, self.operation)
+            redis_sync_pods(self.clients, 2 * http_timeout, self.redis_host, channel, self.logger)
 
         # only do 1 operation at a time in emit_actions
         # so that cache dropping works right
 
         before = datetime.now()
-        json_output_file = os.path.join(self.result_dir,
-                                        "%s.json" % self.operation)
+        json_output_file = os.path.join(self.result_dir, "%s.json" % self.operation)
         network_shared_dir = os.path.join(self.working_dir, "network_shared")
         rsptime_file = os.path.join(network_shared_dir, "stats-rsptimes.csv")
         cmd = [
@@ -101,9 +98,7 @@ class _trigger_smallfile:
             subprocess.check_call(cmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
             self.logger.exception(e)
-            raise SmallfileWrapperException(
-                    "smallfile_cli.py non-zero process return code %d" %
-                    e.returncode)
+            raise SmallfileWrapperException("smallfile_cli.py non-zero process return code %d" % e.returncode)
         self.logger.info(
             "completed sample {} for operation {} , results in {}".format(
                 self.sample, self.operation, json_output_file
@@ -149,10 +144,8 @@ class _trigger_smallfile:
             subprocess.check_call(cmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
             self.logger.exception(e)
-            raise SmallfileWrapperException("rsptime_stats return code %d" %
-                                            e.returncode)
-        self.logger.info("response time result for operation {} in {}".format(
-                            self.operation, rsptime_file))
+            raise SmallfileWrapperException("rsptime_stats return code %d" % e.returncode)
+        self.logger.info("response time result for operation {} in {}".format(self.operation, rsptime_file))
         with open(rsptime_file) as rf:
             lines = [ln.strip() for ln in rf.readlines()]
             start_grabbing = False
@@ -167,9 +160,7 @@ class _trigger_smallfile:
                     interval["iops"] = int(flds[2])
                     if interval["iops"] > 0.0:
                         rsptime_date = int(flds[0])
-                        rsptime_date_str = time.strftime(
-                                                "%Y-%m-%dT%H:%M:%S.000Z",
-                                                time.gmtime(rsptime_date))
+                        rsptime_date_str = time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime(rsptime_date))
                         interval["cluster_name"] = self.cluster_name
                         interval["uuid"] = self.uuid
                         interval["user"] = self.user
@@ -187,10 +178,7 @@ class _trigger_smallfile:
                         yield interval, "rsptimes"
 
         if self.clients > 1 and self.redis_host:
-            channel = 'smallfile-%s-sample-%d-op-%s-after' % (
-                        self.uuid, self.sample, self.operation)
-            extra_timeout = int((datetime.now() - before).seconds
-                                * self.redis_timeout_th / 100)
+            channel = "smallfile-%s-sample-%d-op-%s-after" % (self.uuid, self.sample, self.operation)
+            extra_timeout = int((datetime.now() - before).seconds * self.redis_timeout_th / 100)
             redis_timeout = self.redis_timeout + extra_timeout
-            redis_sync_pods(self.clients, redis_timeout, self.redis_host,
-                            channel, self.logger)
+            redis_sync_pods(self.clients, redis_timeout, self.redis_host, channel, self.logger)

--- a/snafu/utils/sync_pods_with_redis.py
+++ b/snafu/utils/sync_pods_with_redis.py
@@ -18,9 +18,11 @@ def redis_sync_pods(clients, timeout_sec, redis_host, syncpoint_name, logger, so
     )
     for msg in p.listen():
         logger.debug("Complete message from channel: %s" % msg)
-        next_msg = msg["data"].decode("utf-8")
-        if isinstance(msg["data"], bytes) and next_msg == "continue":
-            logger.info("Continue message received on channel %s" % syncpoint_name)
-            break
+        if isinstance(msg["data"], bytes):
+            if msg["data"].decode("utf-8") == "continue":
+                logger.info("Continue message received on channel %s" % syncpoint_name)
+                break
+        else:
+            logger.debug("msg data was not string")
     r.publish(syncpoint_name, "running")
     r.connection_pool.disconnect()

--- a/snafu/utils/sync_pods_with_redis.py
+++ b/snafu/utils/sync_pods_with_redis.py
@@ -1,24 +1,30 @@
 import redis
 
+
 # function to synchronize start / end of benchmark across all pods
 
-def redis_sync_pods(clients, timeout_sec, redis_host, syncpoint_name, logger, socket_port=6379):
-    logger.debug("Redis channel %s timeout %d at %s:6379" % (syncpoint_name, timeout_sec, redis_host))
+def redis_sync_pods(clients, timeout_sec, redis_host, syncpoint_name, logger,
+                    socket_port=6379):
+    logger.debug("Redis channel %s timeout %d at %s:6379" % (
+                    syncpoint_name, timeout_sec, redis_host))
     r = redis.StrictRedis(redis_host, 6379, socket_timeout=timeout_sec)
     p = r.pubsub()
     p.subscribe(syncpoint_name)
     subscribers = int(r.pubsub_numsub(syncpoint_name)[0][1])
     if subscribers == clients:
         r.publish(syncpoint_name, "continue")
-        logger.debug("published signal to go ahead with syncpoint %s" % syncpoint_name)
-    logger.debug("With %d subscribers, awaiting continue message on %s channel" % 
+        logger.debug(
+                "published signal to go ahead with syncpoint %s" %
+                syncpoint_name)
+    logger.debug(
+            "With %d subscribers, awaiting continue message on %s channel" %
             (subscribers, syncpoint_name))
     for msg in p.listen():
         logger.debug("Complete message from channel: %s" % msg)
-        if isinstance(msg["data"], bytes) and msg["data"].decode("utf-8") == "continue":
-            logger.info("Continue message received on channel %s" % syncpoint_name)
+        next_msg = msg["data"].decode("utf-8")
+        if isinstance(msg["data"], bytes) and next_msg == "continue":
+            logger.info("Continue message received on channel %s" %
+                        syncpoint_name)
             break
     r.publish(syncpoint_name, "running")
     r.connection_pool.disconnect()
-
-

--- a/snafu/utils/sync_pods_with_redis.py
+++ b/snafu/utils/sync_pods_with_redis.py
@@ -1,0 +1,24 @@
+import redis
+
+# function to synchronize start / end of benchmark across all pods
+
+def redis_sync_pods(clients, timeout_sec, redis_host, syncpoint_name, logger, socket_port=6379):
+    logger.debug("Redis channel %s timeout %d at %s:6379" % (syncpoint_name, timeout_sec, redis_host))
+    r = redis.StrictRedis(redis_host, 6379, socket_timeout=timeout_sec)
+    p = r.pubsub()
+    p.subscribe(syncpoint_name)
+    subscribers = int(r.pubsub_numsub(syncpoint_name)[0][1])
+    if subscribers == clients:
+        r.publish(syncpoint_name, "continue")
+        logger.debug("published signal to go ahead with syncpoint %s" % syncpoint_name)
+    logger.debug("With %d subscribers, awaiting continue message on %s channel" % 
+            (subscribers, syncpoint_name))
+    for msg in p.listen():
+        logger.debug("Complete message from channel: %s" % msg)
+        if isinstance(msg["data"], bytes) and msg["data"].decode("utf-8") == "continue":
+            logger.info("Continue message received on channel %s" % syncpoint_name)
+            break
+    r.publish(syncpoint_name, "running")
+    r.connection_pool.disconnect()
+
+

--- a/snafu/utils/sync_pods_with_redis.py
+++ b/snafu/utils/sync_pods_with_redis.py
@@ -3,28 +3,24 @@ import redis
 
 # function to synchronize start / end of benchmark across all pods
 
-def redis_sync_pods(clients, timeout_sec, redis_host, syncpoint_name, logger,
-                    socket_port=6379):
-    logger.debug("Redis channel %s timeout %d at %s:6379" % (
-                    syncpoint_name, timeout_sec, redis_host))
+
+def redis_sync_pods(clients, timeout_sec, redis_host, syncpoint_name, logger, socket_port=6379):
+    logger.debug("Redis channel %s timeout %d at %s:6379" % (syncpoint_name, timeout_sec, redis_host))
     r = redis.StrictRedis(redis_host, 6379, socket_timeout=timeout_sec)
     p = r.pubsub()
     p.subscribe(syncpoint_name)
     subscribers = int(r.pubsub_numsub(syncpoint_name)[0][1])
     if subscribers == clients:
         r.publish(syncpoint_name, "continue")
-        logger.debug(
-                "published signal to go ahead with syncpoint %s" %
-                syncpoint_name)
+        logger.debug("published signal to go ahead with syncpoint %s" % syncpoint_name)
     logger.debug(
-            "With %d subscribers, awaiting continue message on %s channel" %
-            (subscribers, syncpoint_name))
+        "With %d subscribers, awaiting continue message on %s channel" % (subscribers, syncpoint_name)
+    )
     for msg in p.listen():
         logger.debug("Complete message from channel: %s" % msg)
         next_msg = msg["data"].decode("utf-8")
         if isinstance(msg["data"], bytes) and next_msg == "continue":
-            logger.info("Continue message received on channel %s" %
-                        syncpoint_name)
+            logger.info("Continue message received on channel %s" % syncpoint_name)
             break
     r.publish(syncpoint_name, "running")
     r.connection_pool.disconnect()


### PR DESCRIPTION
Do not merge yet.
storage benchmarks may have to synchronize pods 2 times per sample, 1 time after cache drop and 1 time after benchmark run
this PR creates common code to simplify pod synchronization to avoid duplication across benchmarks
we try it out with smallfile benchmark to illustrate its use but fio, fs-drift and someday cosbench could use it too.

