### PR TITLE
IOPS floating-point truncation to int results in significant fio errors

### DIFF
--- a/snafu/fio_wrapper/fio_analyzer.py
+++ b/snafu/fio_wrapper/fio_analyzer.py
@@ -82,10 +82,10 @@ class Fio_Analyzer:
                     self.sumdoc[sample][rw][bs_value]["write"] = 0
                     self.sumdoc[sample][rw][bs_value]["read"] = 0
 
-                self.sumdoc[sample][rw][bs_value]["write"] += int(
+                self.sumdoc[sample][rw][bs_value]["write"] += float(
                     fio_result["document"]["fio"]["write"]["iops"]
                 )
-                self.sumdoc[sample][rw][bs_value]["read"] += int(
+                self.sumdoc[sample][rw][bs_value]["read"] += float(
                     fio_result["document"]["fio"]["read"]["iops"]
                 )
 


### PR DESCRIPTION
Do not merge yet, testing, I'll merge as soon as I see it work.

IOPS results in ripsaw-fio-analyzed-result index were way less than sum of per-job (per-process) IOPS results with numjobs=32, this was because the tests in question had per-process IOPS < 1 for 4096-KiB writes, in some cases so int()  truncated them to zero.   In most cases this does not result in such a noticeable error.  