### PR TITLE
Add missing install for snafu in readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,3 +22,5 @@ python:
    version: 3.7
    install:
      - requirements: requirements/py37-reqs/docs.txt
+     - method: pip
+       path: .


### PR DESCRIPTION
Signed-off-by: Ryan Drew <learnitall0@gmail.com>

### Description

Adds missing install statement for snafu within the readthedocs config.

### Fixes

Failing build caused by 'snafu not found': https://readthedocs.org/projects/benchmark-wrapper/builds/14667168/
Example of successful build caused by the fix included in this PR: https://readthedocs.org/projects/my-benchmark-wrapper-fork/builds/14667274/