### PR TITLE
add directory on container because it cannot be created on runtime

### DIFF
--- a/snafu/scale_openshift_wrapper/Dockerfile
+++ b/snafu/scale_openshift_wrapper/Dockerfile
@@ -5,7 +5,9 @@ RUN dnf install -y --nodocs python3 python3-pip jq  && dnf clean all
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz -C /usr/bin/ oc
 RUN curl -L $(curl -s https://api.github.com/repos/openshift/rosa/releases/latest | jq -r ".assets[] | select(.name == \"rosa-linux-amd64\") | .browser_download_url") --output /usr/bin/rosa
-RUN chmod 755 /usr/bin/rosa
+RUN curl -L $(curl -s https://api.github.com/repos/openshift-online/ocm-cli/releases/latest | jq -r ".assets[] | select(.name == \"ocm-linux-amd64\") | .browser_download_url") --output /usr/bin/ocm
+RUN chmod +x /usr/bin/rosa && chmod +x /usr/bin/ocm
+RUN mkdir -p /.config/ocm
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/


### PR DESCRIPTION
During the execution of benchmark-operator, ocm configuration folder cannot be created:

```
$ oc logs -f scale-1f0841af-zq2x4
2021-09-10T10:09:01Z - INFO     - MainProcess - run_snafu: logging level is DEBUG
2021-09-10T10:09:01Z - INFO     - MainProcess - _load_benchmarks: Successfully imported 1 benchmark modules: uperf
2021-09-10T10:09:01Z - INFO     - MainProcess - _load_benchmarks: Failed to import 0 benchmark modules: 
2021-09-10T10:09:01Z - INFO     - MainProcess - run_snafu: Using elasticsearch server with host: ES_SERVER
2021-09-10T10:09:01Z - INFO     - MainProcess - run_snafu: Using index prefix for ES: openshift-cluster-timings
2021-09-10T10:09:01Z - INFO     - MainProcess - run_snafu: Connected to the elasticsearch cluster with info as follows:
2021-09-10T10:09:01Z - WARNING  - MainProcess - run_snafu: Elasticsearch connection caused an exception: ConnectionError(<urllib3.connection.HTTPConnection object at 0x7f3d08b9bb70>: Failed to establish a new connection: [Errno -2] Name or service not known) caused by: NewConnectionError(<urllib3.connection.HTTPConnection object at 0x7f3d08b9bb70>: Failed to establish a new connection: [Errno -2] Name or service not known)
2021-09-10T10:09:01Z - INFO     - MainProcess - run_snafu: Not connected to Elasticsearch
2021-09-10T10:09:01Z - INFO     - MainProcess - wrapper_factory: identified scale as the benchmark wrapper
2021-09-10T10:09:01Z - INFO     - MainProcess - trigger_scale: Identified ROSA for scaling process
2021-09-10T10:09:01Z - INFO     - MainProcess - trigger_scale: Checking ROSA version
2021-09-10T10:09:01Z - DEBUG    - MainProcess - trigger_scale: ['/usr/bin/rosa', 'version']
2021-09-10T10:09:01Z - DEBUG    - MainProcess - trigger_scale: 1.1.2
2021-09-10T10:09:01Z - INFO     - MainProcess - trigger_scale: Detected ROSA version 1.1.2
2021-09-10T10:09:01Z - INFO     - MainProcess - trigger_scale: Attempting to log in ROSA
2021-09-10T10:09:01Z - DEBUG    - MainProcess - trigger_scale: ['/usr/bin/rosa', 'login', '--token=xxxx', '--env=staging']
2021-09-10T10:09:01Z - ERROR    - MainProcess - trigger_scale: Unable to execute ['/usr/bin/rosa', 'login', '--token=xxxx', '--env=staging']
2021-09-10T10:09:01Z - ERROR    - MainProcess - trigger_scale: E: Failed to save config file: Failed to create directory /.config/ocm: mkdir /.config: permission denied
```

