### PR TITLE
add directory on container because it cannot be created on runtime

### DIFF
--- a/snafu/scale_openshift_wrapper/Dockerfile
+++ b/snafu/scale_openshift_wrapper/Dockerfile
@@ -8,6 +8,7 @@ RUN curl -L $(curl -s https://api.github.com/repos/openshift/rosa/releases/lates
 RUN curl -L $(curl -s https://api.github.com/repos/openshift-online/ocm-cli/releases/latest | jq -r ".assets[] | select(.name == \"ocm-linux-amd64\") | .browser_download_url") --output /usr/bin/ocm
 RUN chmod +x /usr/bin/rosa && chmod +x /usr/bin/ocm
 RUN mkdir -p /.config/ocm
+RUN chmod 777 /.config/ocm
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/


### PR DESCRIPTION
It is still failing:

```
2021-09-10T15:12:47Z - ERROR    - MainProcess - trigger_scale: E: Failed to save config file: Failed to write file '/.config/ocm/ocm.json': open /.config/ocm/ocm.json: permission denied
```

