### PR TITLE
change uperf_ts to timestamp as other workloads timestamp

### DIFF
--- a/snafu/benchmarks/uperf/uperf.py
+++ b/snafu/benchmarks/uperf/uperf.py
@@ -95,7 +95,7 @@ class UperfConfig:
 class UperfStat:
     """Parsed Uperf Statistic."""
 
-    uperf_ts: str
+    timestamp: str
     bytes: int
     norm_byte: int
     ops: int
@@ -279,7 +279,7 @@ class Uperf(Benchmark):
                 norm_ltcy = ((timestamp - prev_timestamp) / norm_ops) * 1000
 
             datapoint = UperfStat(
-                uperf_ts=datetime.datetime.fromtimestamp(int(timestamp) / 1000).isoformat(),
+                timestamp=datetime.datetime.now(),
                 bytes=num_bytes,
                 norm_byte=num_bytes - prev_bytes,
                 ops=ops,


### PR DESCRIPTION
### Description
change uperf_ts to timestamp as other workloads timestamp
### Fixes
That current Elasticsearch variable for timestamp is uperf_ts.
The best practice is to use 'timestamp' instead of 'uperf_ts'
Also this is the timestamp variable name in other workloads (stressng, hammerdb)