### PR TITLE
When counting workers, we need to skip workload and infra nodes

### DIFF
--- a/snafu/scale_openshift_wrapper/trigger_scale.py
+++ b/snafu/scale_openshift_wrapper/trigger_scale.py
@@ -173,7 +173,10 @@ class Trigger_scale:
         worker_count = (
             len(
                 nodes.get(
-                    label_selector="node-role.kubernetes.io/worker,!node-role.kubernetes.io/master"
+                    label_selector="node-role.kubernetes.io/worker,"
+                    "!node-role.kubernetes.io/master,"
+                    "!node-role.kubernetes.io/infra,"
+                    "!node-role.kubernetes.io/workload"
                 ).attributes.items
             )
             or 0


### PR DESCRIPTION
```
[morenod@morenod-laptop benchmark-wrapper]$ oc get nodes
NAME                                         STATUS   ROLES             AGE     VERSION
ip-10-0-129-100.us-west-2.compute.internal   Ready    worker            5d23h   v1.21.1+9807387
ip-10-0-135-251.us-west-2.compute.internal   Ready    infra,worker      7d1h    v1.21.1+9807387
ip-10-0-138-40.us-west-2.compute.internal    Ready    worker,workload   5d23h   v1.21.1+9807387
ip-10-0-141-182.us-west-2.compute.internal   Ready    master            7d1h    v1.21.1+9807387
ip-10-0-166-165.us-west-2.compute.internal   Ready    infra,worker      7d1h    v1.21.1+9807387
ip-10-0-170-115.us-west-2.compute.internal   Ready    master            7d1h    v1.21.1+9807387
ip-10-0-170-26.us-west-2.compute.internal    Ready    worker,workload   5d23h   v1.21.1+9807387
ip-10-0-175-28.us-west-2.compute.internal    Ready    worker            5d22h   v1.21.1+9807387
ip-10-0-194-87.us-west-2.compute.internal    Ready    infra,worker      7d1h    v1.21.1+9807387
ip-10-0-206-22.us-west-2.compute.internal    Ready    worker            7d1h    v1.21.1+9807387
ip-10-0-216-216.us-west-2.compute.internal   Ready    master            7d1h    v1.21.1+9807387
ip-10-0-221-164.us-west-2.compute.internal   Ready    worker,workload   5d23h   v1.21.1+9807387

```

If we set to scale to 9, wrapper consider that it is already on 9, because it is including infra and workload workers on the count.
We need to skip those nodes from the count
