### PR TITLE
Python 3.9 migration & container build fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ export es=<http://es_address:es_port>
 ## - Run ##
 
 ```
-python3.7 ./snafu/run_snafu.py --tool <tool name>  followed by tool dependent parameters.
+python3.9 ./snafu/run_snafu.py --tool <tool name>  followed by tool dependent parameters.
 ```
 
 for example:
 
 ```
-python3.7 ./snafu/run_snafu.py --tool sysbench -f example__cpu_test.conf
+python3.9 ./snafu/run_snafu.py --tool sysbench -f example__cpu_test.conf
 ```
 
 ## Archiving data
@@ -72,13 +72,13 @@ To enable writing to an archive file users can use the --create-archive, if user
 For example:
 
 ```
-python3.7 ./snafu/run_snafu.py --tool sysbench -f example__cpu_test.conf --create-archive --archive-file /tmp/my_sysbench_data.archive
+python3.9 ./snafu/run_snafu.py --tool sysbench -f example__cpu_test.conf --create-archive --archive-file /tmp/my_sysbench_data.archive
 ```
 
 To index from an archive file users can invoke run_snafu as follows:
 
 ```
-python3.7 ./snafu/run_snafu.py --tool archive --archive-file /tmp/my_sysbench_data.archive
+python3.9 ./snafu/run_snafu.py --tool archive --archive-file /tmp/my_sysbench_data.archive
 ```
 
  **Note**: The archive file contains Elasticsearch friendly documents per line and is intended for future indexing, so it is not expect that users evaluate or review it manually.

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -1,6 +1,6 @@
 # Installation
 
-Installing benchmark-wrapper is all done through pip and git, requiring Python >= 3.6. For instance, to download benchmark-wrapper and install within a new virtual environment:
+Installing benchmark-wrapper is all done through pip and git, requiring Python >= 3.9. For instance, to download benchmark-wrapper and install within a new virtual environment:
 
 ```console
 $ git clone https://github.com/cloud-bulldozer/benchmark-wrapper
@@ -15,7 +15,7 @@ Or, if you want to just install benchmark-wrapper directly into your user site-p
 $ pip install git+https://github.com/cloud-bulldozer/benchmark-wrapper
 ```
 
-For reproducable installations, use the appropriate pip requirements files for your target version of Python. These requirement files are generating using [pip-compile](https://pypi.org/project/pip-tools/) and include dependencies pinned to a specific version. Only after testing are these versions upgraded, preventing errors arising from dependency resolution. As an example, to install benchmark-wrapper for Python 3.6:
+For reproducable installations, use the appropriate pip requirements files for your target version of Python. These requirement files are generating using [pip-compile](https://pypi.org/project/pip-tools/) and include dependencies pinned to a specific version. Only after testing are these versions upgraded, preventing errors arising from dependency resolution. As an example, to install benchmark-wrapper for Python 3.9:
 
 ```console
 $ git clone https://github.com/cloud-bulldozer/benchmark-wrapper

--- a/snafu/benchmarks/uperf/Dockerfile
+++ b/snafu/benchmarks/uperf/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8:latest
 
-RUN dnf install -y --nodocs git python3-pip && dnf clean all
+RUN dnf install -y --nodocs git python39-pip && dnf clean all
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
 RUN dnf install -y --nodocs hostname procps-ng iproute net-tools ethtool nmap iputils https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && dnf clean all

--- a/snafu/benchmarks/uperf/Dockerfile
+++ b/snafu/benchmarks/uperf/Dockerfile
@@ -1,11 +1,11 @@
 FROM registry.access.redhat.com/ubi8:latest
 
-RUN dnf install -y --nodocs git python39-pip && dnf clean all
+RUN dnf install -y --nodocs git python39 && dnf clean all
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
 RUN dnf install -y --nodocs hostname procps-ng iproute net-tools ethtool nmap iputils https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && dnf clean all
 RUN dnf install -y uperf && dnf clean all
 RUN ln -s /usr/bin/python3 /usr/bin/python
-RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/

--- a/snafu/benchmarks/uperf/Dockerfile.ppc64le
+++ b/snafu/benchmarks/uperf/Dockerfile.ppc64le
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8:latest
 
-RUN dnf install -y --nodocs git python3 python3-pip gcc python3-devel gcc-c++ atlas-devel gcc-gfortran  && dnf clean all
+RUN dnf install -y --nodocs git python39 python39-pip gcc python39-devel gcc-c++ atlas-devel gcc-gfortran  && dnf clean all
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
 RUN dnf install -y --nodocs hostname procps-ng iproute net-tools ethtool nmap iputils https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && dnf clean all

--- a/snafu/benchmarks/uperf/Dockerfile.ppc64le
+++ b/snafu/benchmarks/uperf/Dockerfile.ppc64le
@@ -1,12 +1,11 @@
 FROM registry.access.redhat.com/ubi8:latest
 
-RUN dnf install -y --nodocs git python39 python39-pip gcc python39-devel gcc-c++ atlas-devel gcc-gfortran  && dnf clean all
+RUN dnf install -y --nodocs git python39 gcc python39-devel gcc-c++ atlas-devel gcc-gfortran  && dnf clean all
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
 RUN dnf install -y --nodocs hostname procps-ng iproute net-tools ethtool nmap iputils https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && dnf clean all
 RUN dnf install -y uperf && dnf clean all
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN python3 -m pip install --upgrade cython numpy importlib_metadata 'urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1' && python3 -m pip install --upgrade scipy pandas
-RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/
 RUN pip3 install -e /opt/snafu/

--- a/snafu/cyclictest_wrapper/Dockerfile
+++ b/snafu/cyclictest_wrapper/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.centos.org/centos:8
 USER root
-RUN dnf install -y --nodocs python3 python3-pip python3-devel numactl-devel perl \
+RUN dnf install -y --nodocs python39-pip python39-devel numactl-devel perl \
     epel-release procps-ng iproute net-tools ethtool nmap iputils
 RUN dnf -y install https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/rt-tests-1.9-2.el8.x86_64.rpm
 RUN dnf -y --enablerepo=extras install --nodocs wget tmux stress-ng \

--- a/snafu/cyclictest_wrapper/Dockerfile
+++ b/snafu/cyclictest_wrapper/Dockerfile
@@ -1,11 +1,12 @@
 FROM registry.centos.org/centos:8
 USER root
-RUN dnf install -y --nodocs python39-pip python39-devel numactl-devel perl \
+RUN dnf install -y --nodocs python39-devel numactl-devel perl \
     epel-release procps-ng iproute net-tools ethtool nmap iputils
 RUN dnf -y install https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/rt-tests-1.9-2.el8.x86_64.rpm
 RUN dnf -y --enablerepo=extras install --nodocs wget tmux stress-ng \
     https://cbs.centos.org/kojifiles/packages/dumb-init/1.2.2/6.el8/x86_64/dumb-init-1.2.2-6.el8.x86_64.rpm \
     && dnf clean all && rm -rf /var/cache/yum
 COPY . /opt/snafu
-RUN pip3 install -e /opt/snafu/
 RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN pip3 install --upgrade pip
+RUN pip3 install -e /opt/snafu/

--- a/snafu/cyclictest_wrapper/Dockerfile
+++ b/snafu/cyclictest_wrapper/Dockerfile
@@ -2,8 +2,8 @@ FROM registry.fedoraproject.org/fedora:34
 USER root
 RUN dnf install -y --nodocs python39 python3-devel numactl-devel perl \
     procps-ng iproute net-tools ethtool nmap iputils \
-	rt-tests dumb-init wget tmux stress-ng \
-	&& dnf clean all && rm -rf /var/cache/yum
+    rt-tests dumb-init wget tmux stress-ng \
+    && dnf clean all && rm -rf /var/cache/yum
 COPY . /opt/snafu
 RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/

--- a/snafu/cyclictest_wrapper/Dockerfile
+++ b/snafu/cyclictest_wrapper/Dockerfile
@@ -1,9 +1,9 @@
 FROM registry.fedoraproject.org/fedora:34
 USER root
-RUN dnf install -y --nodocs python39 python3-devel numactl-devel perl \
+RUN dnf install -y --nodocs python3 python3-pip python3-devel numactl-devel perl \
     procps-ng iproute net-tools ethtool nmap iputils \
     rt-tests dumb-init wget tmux stress-ng \
     && dnf clean all && rm -rf /var/cache/yum
 COPY . /opt/snafu
-RUN pip3 install --upgrade pip
-RUN pip3 install -e /opt/snafu/
+RUN pip install --upgrade pip
+RUN pip install -e /opt/snafu/

--- a/snafu/cyclictest_wrapper/Dockerfile
+++ b/snafu/cyclictest_wrapper/Dockerfile
@@ -1,12 +1,9 @@
-FROM registry.centos.org/centos:8
+FROM registry.fedoraproject.org/fedora:34
 USER root
-RUN dnf install -y --nodocs python39-devel numactl-devel perl \
-    epel-release procps-ng iproute net-tools ethtool nmap iputils
-RUN dnf -y install https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/rt-tests-1.9-2.el8.x86_64.rpm
-RUN dnf -y --enablerepo=extras install --nodocs wget tmux stress-ng \
-    https://cbs.centos.org/kojifiles/packages/dumb-init/1.2.2/6.el8/x86_64/dumb-init-1.2.2-6.el8.x86_64.rpm \
-    && dnf clean all && rm -rf /var/cache/yum
+RUN dnf install -y --nodocs python39 python3-devel numactl-devel perl \
+    procps-ng iproute net-tools ethtool nmap iputils \
+	rt-tests dumb-init wget tmux stress-ng \
+	&& dnf clean all && rm -rf /var/cache/yum
 COPY . /opt/snafu
-RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/

--- a/snafu/dns_perf_wrapper/Dockerfile
+++ b/snafu/dns_perf_wrapper/Dockerfile
@@ -1,11 +1,12 @@
-FROM registry.access.redhat.com/ubi8:latest
+FROM registry.centos.org/centos:8
 
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y epel-release && dnf install -y --nodocs redis python39 python39-pip openssl-devel ck-devel yum-plugin-copr && \
+RUN dnf install -y epel-release && dnf install -y --nodocs redis python39 openssl-devel ck-devel yum-plugin-copr && \
     dnf copr enable @dnsoarc/dnsperf -y && \
     dnf install dnsperf -y && \
     dnf clean all && rm -rf /var/cache/yum
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz -C /usr/bin/ oc && ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/

--- a/snafu/dns_perf_wrapper/Dockerfile
+++ b/snafu/dns_perf_wrapper/Dockerfile
@@ -1,7 +1,7 @@
-FROM registry.centos.org/centos:8
+FROM registry.access.redhat.com/ubi8:latest
 
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y epel-release && dnf install -y --nodocs redis python3 python3-pip openssl-devel ck-devel yum-plugin-copr && \
+RUN dnf install -y epel-release && dnf install -y --nodocs redis python39 python39-pip openssl-devel ck-devel yum-plugin-copr && \
     dnf copr enable @dnsoarc/dnsperf -y && \
     dnf install dnsperf -y && \
     dnf clean all && rm -rf /var/cache/yum

--- a/snafu/dns_perf_wrapper/Dockerfile
+++ b/snafu/dns_perf_wrapper/Dockerfile
@@ -6,7 +6,6 @@ RUN dnf install -y epel-release && dnf install -y --nodocs redis python39 openss
     dnf install dnsperf -y && \
     dnf clean all && rm -rf /var/cache/yum
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz -C /usr/bin/ oc && ln -s /usr/bin/python3 /usr/bin/python
-RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/
 RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/

--- a/snafu/fio_wrapper/Dockerfile
+++ b/snafu/fio_wrapper/Dockerfile
@@ -6,7 +6,7 @@ RUN pushd fio-fio-3.27 && ./configure --disable-native && make -j2
 
 FROM registry.access.redhat.com/ubi8:latest
 COPY --from=builder /fio-fio-3.27/fio /usr/local/bin/fio
-RUN dnf install -y --nodocs git python3-pip libaio zlib procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
+RUN dnf install -y --nodocs git python39-pip libaio zlib procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
 RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY . /opt/snafu
 RUN pip3 install -e /opt/snafu/

--- a/snafu/fio_wrapper/Dockerfile
+++ b/snafu/fio_wrapper/Dockerfile
@@ -6,7 +6,8 @@ RUN pushd fio-fio-3.27 && ./configure --disable-native && make -j2
 
 FROM registry.access.redhat.com/ubi8:latest
 COPY --from=builder /fio-fio-3.27/fio /usr/local/bin/fio
-RUN dnf install -y --nodocs git python39-pip libaio zlib procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
+RUN dnf install -y --nodocs python39 git libaio zlib procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
 RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY . /opt/snafu
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/

--- a/snafu/fio_wrapper/Dockerfile.ppc64le
+++ b/snafu/fio_wrapper/Dockerfile.ppc64le
@@ -6,8 +6,9 @@ RUN pushd fio-fio-3.27 && ./configure --disable-native && make -j2
 
 FROM registry.access.redhat.com/ubi8:latest
 COPY --from=builder /fio-fio-3.27/fio /usr/local/bin/fio
-RUN dnf install -y --nodocs git python39-pip libaio zlib procps-ng iproute net-tools ethtool nmap iputils python39 gcc python39-devel gcc-c++ atlas-devel gcc-gfortran && dnf clean all
+RUN dnf install -y --nodocs git libaio zlib procps-ng iproute net-tools ethtool nmap iputils python39 gcc python39-devel gcc-c++ atlas-devel gcc-gfortran && dnf clean all
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN python3 -m pip install --upgrade cython numpy importlib_metadata 'urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1' && python3 -m pip install --upgrade scipy pandas
 COPY . /opt/snafu
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/

--- a/snafu/fio_wrapper/Dockerfile.ppc64le
+++ b/snafu/fio_wrapper/Dockerfile.ppc64le
@@ -6,7 +6,7 @@ RUN pushd fio-fio-3.27 && ./configure --disable-native && make -j2
 
 FROM registry.access.redhat.com/ubi8:latest
 COPY --from=builder /fio-fio-3.27/fio /usr/local/bin/fio
-RUN dnf install -y --nodocs git python3-pip libaio zlib procps-ng iproute net-tools ethtool nmap iputils python3 gcc python3-devel gcc-c++ atlas-devel gcc-gfortran && dnf clean all
+RUN dnf install -y --nodocs git python39-pip libaio zlib procps-ng iproute net-tools ethtool nmap iputils python39 gcc python39-devel gcc-c++ atlas-devel gcc-gfortran && dnf clean all
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN python3 -m pip install --upgrade cython numpy importlib_metadata 'urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1' && python3 -m pip install --upgrade scipy pandas
 COPY . /opt/snafu

--- a/snafu/flent_wrapper/Dockerfile
+++ b/snafu/flent_wrapper/Dockerfile
@@ -21,7 +21,7 @@ RUN cd iperf2-code && git checkout bf687b4aac023b303cea08bd1a7248d62ad70f47 && .
 FROM registry.access.redhat.com/ubi8:latest
 
 COPY /snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs git python3-pip iputils redis --enablerepo=centos8-appstream && dnf clean all
+RUN dnf install -y --nodocs git python39-pip iputils redis --enablerepo=centos8-appstream && dnf clean all
 
 RUN pip3 install flent
 

--- a/snafu/flent_wrapper/Dockerfile
+++ b/snafu/flent_wrapper/Dockerfile
@@ -8,12 +8,14 @@ RUN mkdir /tmp/install
 WORKDIR /root
 RUN wget https://github.com/HewlettPackard/netperf/archive/netperf-2.7.0.tar.gz && tar -xzf netperf-2.7.0.tar.gz
 WORKDIR /root/netperf-netperf-2.7.0
+# Workaround: We need to download latest version of config.guess to make configure able to detect other CPU architectures correctly
+RUN curl 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' -o config.guess
 RUN sed -i 's/inline void demo_interval_display(double actual_interval)/void demo_interval_display(double actual_interval)/g' src/netlib.c && sed -i 's/inline void demo_interval_tick(uint32_t units)/void demo_interval_tick(uint32_t units)/g' src/netlib.c
-RUN ./configure --enable-demo --prefix=/tmp/install && make && make install
+RUN ./configure --enable-demo --prefix=/tmp/install && make -j $(nprocs) && make install
 
 # Build iperf2
 WORKDIR /root
-RUN git clone -n https://git.code.sf.net/p/iperf2/code iperf2-code --depth=1
+RUN git clone -n https://git.code.sf.net/p/iperf2/code iperf2-code
 # A specific commit must be specified because the following one introduced a breaking change for flent
 RUN cd iperf2-code && git checkout bf687b4aac023b303cea08bd1a7248d62ad70f47 && ./configure --prefix=/tmp/install && make && make install
 

--- a/snafu/flent_wrapper/Dockerfile
+++ b/snafu/flent_wrapper/Dockerfile
@@ -13,7 +13,7 @@ RUN ./configure --enable-demo --prefix=/tmp/install && make && make install
 
 # Build iperf2
 WORKDIR /root
-RUN git clone -n https://git.code.sf.net/p/iperf2/code iperf2-code
+RUN git clone -n https://git.code.sf.net/p/iperf2/code iperf2-code --depth=1
 # A specific commit must be specified because the following one introduced a breaking change for flent
 RUN cd iperf2-code && git checkout bf687b4aac023b303cea08bd1a7248d62ad70f47 && ./configure --prefix=/tmp/install && make && make install
 
@@ -21,7 +21,7 @@ RUN cd iperf2-code && git checkout bf687b4aac023b303cea08bd1a7248d62ad70f47 && .
 FROM registry.access.redhat.com/ubi8:latest
 
 COPY /snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs git python39-pip iputils redis --enablerepo=centos8-appstream && dnf clean all
+RUN dnf install -y --nodocs python39 git iputils redis --enablerepo=centos8-appstream && dnf clean all
 
 RUN pip3 install flent
 
@@ -31,6 +31,6 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY --from=builder /tmp/install/bin/* /bin/
 
 # Add snafu
-RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/

--- a/snafu/fs_drift_wrapper/Dockerfile
+++ b/snafu/fs_drift_wrapper/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8:latest
 
-RUN dnf install -y --nodocs git python3-pip
+RUN dnf install -y --nodocs git python39-pip
 RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY . /opt/snafu/
 RUN pip3 install -e /opt/snafu/

--- a/snafu/fs_drift_wrapper/Dockerfile
+++ b/snafu/fs_drift_wrapper/Dockerfile
@@ -1,8 +1,9 @@
 FROM registry.access.redhat.com/ubi8:latest
 
-RUN dnf install -y --nodocs git python39-pip
+RUN dnf install -y --nodocs git python39
 RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY . /opt/snafu/
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/
 ADD https://api.github.com/repos/parallel-fs-utils/fs-drift/git/refs/heads/master /tmp/bustcache
 RUN git clone https://github.com/parallel-fs-utils/fs-drift /opt/fs-drift --depth 1

--- a/snafu/fs_drift_wrapper/Dockerfile.ppc64le
+++ b/snafu/fs_drift_wrapper/Dockerfile.ppc64le
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8:latest
 
-RUN dnf install -y --nodocs git python3 python3-pip gcc python3-devel gcc-c++ atlas-devel gcc-gfortran
+RUN dnf install -y --nodocs git python39 python39-pip gcc python39-devel gcc-c++ atlas-devel gcc-gfortran
 RUN dnf install -y --nodocs procps-ng iproute net-tools ethtool nmap iputils
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN python3 -m pip install --upgrade cython numpy importlib_metadata 'urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1' && python3 -m pip install --upgrade scipy pandas

--- a/snafu/fs_drift_wrapper/Dockerfile.ppc64le
+++ b/snafu/fs_drift_wrapper/Dockerfile.ppc64le
@@ -1,10 +1,11 @@
 FROM registry.access.redhat.com/ubi8:latest
 
-RUN dnf install -y --nodocs git python39 python39-pip gcc python39-devel gcc-c++ atlas-devel gcc-gfortran
+RUN dnf install -y --nodocs git python39 gcc python39-devel gcc-c++ atlas-devel gcc-gfortran
 RUN dnf install -y --nodocs procps-ng iproute net-tools ethtool nmap iputils
 RUN ln -s /usr/bin/python3 /usr/bin/python
-RUN python3 -m pip install --upgrade cython numpy importlib_metadata 'urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1' && python3 -m pip install --upgrade scipy pandas
+RUN python3 -m pip install --upgrade pip cython numpy importlib_metadata 'urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1' && python3 -m pip install --upgrade scipy pandas
 COPY . /opt/snafu/
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/
 ADD https://api.github.com/repos/parallel-fs-utils/fs-drift/git/refs/heads/master /tmp/bustcache
 RUN git clone https://github.com/parallel-fs-utils/fs-drift /opt/fs-drift --depth 1

--- a/snafu/hammerdb/Dockerfile
+++ b/snafu/hammerdb/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi8:latest
 # install requirements
 COPY snafu/image_resources/centos8.repo /etc/yum.repos.d/centos8.repo
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --enablerepo=centos8 --enablerepo=centos8-appstream --nodocs python39 tcl unixODBC python39-requests
+RUN dnf install -y --enablerepo=centos8 --enablerepo=centos8-appstream --nodocs python39 tcl unixODBC
 RUN dnf install -y --enablerepo=centos8 --enablerepo=centos8-appstream --nodocs procps-ng iproute net-tools ethtool nmap iputils
 RUN dnf -y install --enablerepo=centos8 --enablerepo=centos8-appstream --nodocs mysql-libs mysql-common mysql-devel mysql-errmsg libpq
 

--- a/snafu/hammerdb/Dockerfile
+++ b/snafu/hammerdb/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi8:latest
 # install requirements
 COPY snafu/image_resources/centos8.repo /etc/yum.repos.d/centos8.repo
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --enablerepo=centos8 --enablerepo=centos8-appstream --nodocs tcl unixODBC python3-pip python3-requests
+RUN dnf install -y --enablerepo=centos8 --enablerepo=centos8-appstream --nodocs tcl unixODBC python39-pip python39-requests
 RUN dnf install -y --enablerepo=centos8 --enablerepo=centos8-appstream --nodocs procps-ng iproute net-tools ethtool nmap iputils
 RUN dnf -y install --enablerepo=centos8 --enablerepo=centos8-appstream --nodocs mysql-libs mysql-common mysql-devel mysql-errmsg libpq
 

--- a/snafu/hammerdb/Dockerfile
+++ b/snafu/hammerdb/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi8:latest
 # install requirements
 COPY snafu/image_resources/centos8.repo /etc/yum.repos.d/centos8.repo
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --enablerepo=centos8 --enablerepo=centos8-appstream --nodocs tcl unixODBC python39-pip python39-requests
+RUN dnf install -y --enablerepo=centos8 --enablerepo=centos8-appstream --nodocs python39 tcl unixODBC python39-requests
 RUN dnf install -y --enablerepo=centos8 --enablerepo=centos8-appstream --nodocs procps-ng iproute net-tools ethtool nmap iputils
 RUN dnf -y install --enablerepo=centos8 --enablerepo=centos8-appstream --nodocs mysql-libs mysql-common mysql-devel mysql-errmsg libpq
 

--- a/snafu/image_pull_wrapper/Dockerfile
+++ b/snafu/image_pull_wrapper/Dockerfile
@@ -1,9 +1,9 @@
 FROM docker://registry.access.redhat.com/ubi8:latest
 
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs python39 python39-pip && dnf clean all
+RUN dnf install -y --nodocs python39 && dnf clean all
 RUN dnf install -y --nodocs skopeo redis --enablerepo=centos8-appstream && dnf clean all
 RUN ln -s /usr/bin/python3 /usr/bin/python
-RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/

--- a/snafu/image_pull_wrapper/Dockerfile
+++ b/snafu/image_pull_wrapper/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker://registry.access.redhat.com/ubi8:latest
 
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs python3 python3-pip && dnf clean all
+RUN dnf install -y --nodocs python39 python39-pip && dnf clean all
 RUN dnf install -y --nodocs skopeo redis --enablerepo=centos8-appstream && dnf clean all
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir -p /opt/snafu/

--- a/snafu/linpack_wrapper/Dockerfile
+++ b/snafu/linpack_wrapper/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8:latest
 
-RUN dnf install -y --nodocs python3-pip
+RUN dnf install -y --nodocs python39-pip
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/

--- a/snafu/linpack_wrapper/Dockerfile
+++ b/snafu/linpack_wrapper/Dockerfile
@@ -1,10 +1,9 @@
 FROM registry.access.redhat.com/ubi8:latest
 
-RUN dnf install -y --nodocs python39-pip
+RUN dnf install -y --nodocs python39
 RUN ln -s /usr/bin/python3 /usr/bin/python
-RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/
 
-RUN curl https://software.intel.com/content/dam/develop/external/us/en/documents/l_onemklbench_p_2021.2.0_109.tgz --output linpack.tgz
-RUN tar xzvf linpack.tgz -C /opt
+RUN curl https://software.intel.com/content/dam/develop/external/us/en/documents/l_onemklbench_p_2021.2.0_109.tgz | tar xvz -C /opt

--- a/snafu/log_generator_wrapper/Dockerfile
+++ b/snafu/log_generator_wrapper/Dockerfile
@@ -1,11 +1,11 @@
 FROM registry.access.redhat.com/ubi8:latest
 
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs python39 python39-pip && dnf clean all
+RUN dnf install -y --nodocs python39 && dnf clean all
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz -C /usr/bin/ oc
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN pip3 install kafka-python
-RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/

--- a/snafu/log_generator_wrapper/Dockerfile
+++ b/snafu/log_generator_wrapper/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8:latest
 
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs python3 python3-pip && dnf clean all
+RUN dnf install -y --nodocs python39 python39-pip && dnf clean all
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz -C /usr/bin/ oc
 RUN ln -s /usr/bin/python3 /usr/bin/python

--- a/snafu/oslat_wrapper/Dockerfile
+++ b/snafu/oslat_wrapper/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.fedoraproject.org/fedora:34
 USER root
 RUN dnf install -y --nodocs python39 python3-devel numactl-devel perl \
     procps-ng iproute net-tools ethtool nmap iputils dumb-init rt-tests \
-	wget tmux && dnf clean all && rm -rf /var/cache/yum
+    wget tmux && dnf clean all && rm -rf /var/cache/yum
 COPY . /opt/snafu
 RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/

--- a/snafu/oslat_wrapper/Dockerfile
+++ b/snafu/oslat_wrapper/Dockerfile
@@ -1,9 +1,8 @@
-FROM registry.centos.org/centos:8
+FROM registry.fedoraproject.org/fedora:34
 USER root
-RUN dnf install -y --nodocs python39 python39-devel numactl-devel perl \
-    epel-release procps-ng iproute net-tools ethtool nmap iputils dumb-init rt-tests \
+RUN dnf install -y --nodocs python39 python3-devel numactl-devel perl \
+    procps-ng iproute net-tools ethtool nmap iputils dumb-init rt-tests \
 	wget tmux && dnf clean all && rm -rf /var/cache/yum
 COPY . /opt/snafu
 RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/
-RUN ln -s /usr/bin/python3 /usr/bin/python

--- a/snafu/oslat_wrapper/Dockerfile
+++ b/snafu/oslat_wrapper/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.fedoraproject.org/fedora:34
 USER root
-RUN dnf install -y --nodocs python39 python3-devel numactl-devel perl \
+RUN dnf install -y --nodocs python3 python3-pip python3-devel numactl-devel perl \
     procps-ng iproute net-tools ethtool nmap iputils dumb-init rt-tests \
     wget tmux && dnf clean all && rm -rf /var/cache/yum
 COPY . /opt/snafu

--- a/snafu/oslat_wrapper/Dockerfile
+++ b/snafu/oslat_wrapper/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.centos.org/centos:8
 USER root
-RUN dnf install -y --nodocs python3 python3-pip python3-devel numactl-devel perl \
+RUN dnf install -y --nodocs python39 python39-pip python39-devel numactl-devel perl \
     epel-release procps-ng iproute net-tools ethtool nmap iputils
 RUN dnf -y install -y https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/rt-tests-1.9-2.el8.x86_64.rpm
 RUN dnf -y --enablerepo=extras install --nodocs wget tmux \

--- a/snafu/oslat_wrapper/Dockerfile
+++ b/snafu/oslat_wrapper/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream8
+FROM registry.centos.org/centos:8
 USER root
 RUN dnf install -y --nodocs python39 python39-devel numactl-devel perl \
     epel-release procps-ng iproute net-tools ethtool nmap iputils dumb-init rt-tests \

--- a/snafu/oslat_wrapper/Dockerfile
+++ b/snafu/oslat_wrapper/Dockerfile
@@ -1,11 +1,9 @@
-FROM registry.centos.org/centos:8
+FROM quay.io/centos/centos:stream8
 USER root
-RUN dnf install -y --nodocs python39 python39-pip python39-devel numactl-devel perl \
-    epel-release procps-ng iproute net-tools ethtool nmap iputils
-RUN dnf -y install -y https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/rt-tests-1.9-2.el8.x86_64.rpm
-RUN dnf -y --enablerepo=extras install --nodocs wget tmux \
-    https://cbs.centos.org/kojifiles/packages/dumb-init/1.2.2/6.el8/x86_64/dumb-init-1.2.2-6.el8.x86_64.rpm \
-    && dnf clean all && rm -rf /var/cache/yum
+RUN dnf install -y --nodocs python39 python39-devel numactl-devel perl \
+    epel-release procps-ng iproute net-tools ethtool nmap iputils dumb-init rt-tests \
+	wget tmux && dnf clean all && rm -rf /var/cache/yum
 COPY . /opt/snafu
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/
 RUN ln -s /usr/bin/python3 /usr/bin/python

--- a/snafu/pgbench_wrapper/Dockerfile
+++ b/snafu/pgbench_wrapper/Dockerfile
@@ -1,11 +1,10 @@
 FROM registry.access.redhat.com/ubi8:latest
 
 RUN dnf install -y --nodocs https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-$(arch)/pgdg-redhat-repo-latest.noarch.rpm
-RUN dnf install -y --nodocs --nogpgcheck postgresql11
+RUN dnf install -y --nodocs --nogpgcheck postgresql11 && dnf clean all
 RUN dnf remove -y pgdg-redhat-repo
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream
-RUN dnf install -y --nodocs procps-ng iproute net-tools ethtool nmap iputils
+RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf install -y --nodocs procps-ng iproute net-tools ethtool nmap iputils python39 && dnf clean all
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN ln -s /usr/pgsql-11/bin/pgbench /usr/bin/pgbench
 RUN mkdir -p /opt/snafu/

--- a/snafu/pgbench_wrapper/Dockerfile
+++ b/snafu/pgbench_wrapper/Dockerfile
@@ -1,7 +1,8 @@
 FROM registry.access.redhat.com/ubi8:latest
 
-RUN dnf install -y --nodocs https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-RUN dnf install -y --nodocs python39-pip postgresql11
+RUN dnf install -y --nodocs https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-$(arch)/pgdg-redhat-repo-latest.noarch.rpm
+RUN dnf install -y --nodocs --nogpgcheck postgresql11
+RUN dnf remove -y pgdg-redhat-repo
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream
 RUN dnf install -y --nodocs procps-ng iproute net-tools ethtool nmap iputils
@@ -9,4 +10,5 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN ln -s /usr/pgsql-11/bin/pgbench /usr/bin/pgbench
 RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/

--- a/snafu/pgbench_wrapper/Dockerfile
+++ b/snafu/pgbench_wrapper/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8:latest
 
 RUN dnf install -y --nodocs https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-RUN dnf install -y --nodocs python3-pip postgresql11
+RUN dnf install -y --nodocs python39-pip postgresql11
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream
 RUN dnf install -y --nodocs procps-ng iproute net-tools ethtool nmap iputils

--- a/snafu/scale_openshift_wrapper/Dockerfile
+++ b/snafu/scale_openshift_wrapper/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8:latest
 
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs python39 python39-pip jq  && dnf clean all
+RUN dnf install -y --nodocs python39 jq  && dnf clean all
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz -C /usr/bin/ oc
 RUN curl -L $(curl -s https://api.github.com/repos/openshift/rosa/releases/latest | jq -r ".assets[] | select(.name == \"rosa-linux-amd64\") | .browser_download_url") --output /usr/bin/rosa
@@ -10,6 +10,6 @@ RUN chmod +x /usr/bin/rosa && chmod +x /usr/bin/ocm
 RUN mkdir -p /.config/ocm
 RUN chmod 777 /.config/ocm
 RUN ln -s /usr/bin/python3 /usr/bin/python
-RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/

--- a/snafu/scale_openshift_wrapper/Dockerfile
+++ b/snafu/scale_openshift_wrapper/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8:latest
 
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs python3 python3-pip jq  && dnf clean all
+RUN dnf install -y --nodocs python39 python39-pip jq  && dnf clean all
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz -C /usr/bin/ oc
 RUN curl -L $(curl -s https://api.github.com/repos/openshift/rosa/releases/latest | jq -r ".assets[] | select(.name == \"rosa-linux-amd64\") | .browser_download_url") --output /usr/bin/rosa

--- a/snafu/scale_openshift_wrapper/Dockerfile.ppc64le
+++ b/snafu/scale_openshift_wrapper/Dockerfile.ppc64le
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8:latest
 
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs python39 python39-pip gcc python39-devel gcc-c++ atlas-devel gcc-gfortran && dnf clean all
+RUN dnf install -y --nodocs python39 gcc python39-devel gcc-c++ atlas-devel gcc-gfortran && dnf clean all
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz -C /usr/bin/ oc
 RUN ln -s /usr/bin/python3 /usr/bin/python

--- a/snafu/scale_openshift_wrapper/Dockerfile.ppc64le
+++ b/snafu/scale_openshift_wrapper/Dockerfile.ppc64le
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8:latest
 
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs python3 python3-pip gcc python3-devel gcc-c++ atlas-devel gcc-gfortran && dnf clean all
+RUN dnf install -y --nodocs python39 python39-pip gcc python39-devel gcc-c++ atlas-devel gcc-gfortran && dnf clean all
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz -C /usr/bin/ oc
 RUN ln -s /usr/bin/python3 /usr/bin/python

--- a/snafu/scale_openshift_wrapper/Dockerfile.ppc64le
+++ b/snafu/scale_openshift_wrapper/Dockerfile.ppc64le
@@ -6,6 +6,5 @@ RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean al
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz -C /usr/bin/ oc
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN python3 -m pip install --upgrade cython numpy importlib_metadata 'urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1' && python3 -m pip install --upgrade scipy pandas
-RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/
 RUN pip3 install -e /opt/snafu/

--- a/snafu/smallfile_wrapper/Dockerfile
+++ b/snafu/smallfile_wrapper/Dockerfile
@@ -1,10 +1,11 @@
 FROM registry.access.redhat.com/ubi8:latest
 
-RUN dnf install -y --nodocs git python39-pip
+RUN dnf install -y --nodocs git python39
 RUN ln -s /usr/bin/python3 /usr/bin/python
 ADD https://api.github.com/repos/distributed-system-analysis/smallfile/git/refs/heads/master /tmp/bustcache
-RUN git clone https://github.com/distributed-system-analysis/smallfile /opt/smallfile
+RUN git clone https://github.com/distributed-system-analysis/smallfile /opt/smallfile --depth=1
 RUN ln -sv /opt/smallfile/smallfile_cli.py /usr/local/bin/
 RUN ln -sv /opt/smallfile/smallfile_rsptimes_stats.py /usr/local/bin/
 COPY . /opt/snafu/
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/

--- a/snafu/smallfile_wrapper/Dockerfile
+++ b/snafu/smallfile_wrapper/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8:latest
 
-RUN dnf install -y --nodocs git python3-pip
+RUN dnf install -y --nodocs git python39-pip
 RUN ln -s /usr/bin/python3 /usr/bin/python
 ADD https://api.github.com/repos/distributed-system-analysis/smallfile/git/refs/heads/master /tmp/bustcache
 RUN git clone https://github.com/distributed-system-analysis/smallfile /opt/smallfile

--- a/snafu/smallfile_wrapper/Dockerfile.ppc64le
+++ b/snafu/smallfile_wrapper/Dockerfile.ppc64le
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8:latest
 
-RUN dnf install -y --nodocs git python3 python3-pip gcc python3-devel gcc-c++ atlas-devel gcc-gfortran
+RUN dnf install -y --nodocs git python39 python39-pip gcc python39-devel gcc-c++ atlas-devel gcc-gfortran
 RUN dnf install -y --nodocs procps-ng iproute net-tools ethtool nmap iputils
 RUN ln -s /usr/bin/python3 /usr/bin/python
 ADD https://api.github.com/repos/distributed-system-analysis/smallfile/git/refs/heads/master /tmp/bustcache

--- a/snafu/smallfile_wrapper/Dockerfile.ppc64le
+++ b/snafu/smallfile_wrapper/Dockerfile.ppc64le
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8:latest
 
-RUN dnf install -y --nodocs git python39 python39-pip gcc python39-devel gcc-c++ atlas-devel gcc-gfortran
+RUN dnf install -y --nodocs git python39 gcc python39-devel gcc-c++ atlas-devel gcc-gfortran
 RUN dnf install -y --nodocs procps-ng iproute net-tools ethtool nmap iputils
 RUN ln -s /usr/bin/python3 /usr/bin/python
 ADD https://api.github.com/repos/distributed-system-analysis/smallfile/git/refs/heads/master /tmp/bustcache

--- a/snafu/stressng_wrapper/Dockerfile
+++ b/snafu/stressng_wrapper/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.access.redhat.com/ubi8:latest
 COPY snafu/image_resources/centos8.repo /etc/yum.repos.d/centos8.repo
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-RUN dnf install -y --enablerepo=centos8 --enablerepo=centos8-appstream --enablerepo=epel --nodocs stress-ng python3-pip python3-requests
+RUN dnf install -y --enablerepo=centos8 --enablerepo=centos8-appstream --enablerepo=epel --nodocs stress-ng python39-pip python39-requests
 RUN dnf install -y --enablerepo=centos8 --enablerepo=centos8-appstream --nodocs procps-ng iproute net-tools ethtool nmap iputils
 
 RUN dnf clean all

--- a/snafu/stressng_wrapper/Dockerfile
+++ b/snafu/stressng_wrapper/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.access.redhat.com/ubi8:latest
 COPY snafu/image_resources/centos8.repo /etc/yum.repos.d/centos8.repo
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm python39 && dnf clean all
-RUN dnf install -y --enablerepo=centos8 --enablerepo=centos8-appstream --enablerepo=epel --nodocs stress-ng python39-requests \
+RUN dnf install -y --enablerepo=centos8 --enablerepo=centos8-appstream --enablerepo=epel --nodocs stress-ng \
     procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
 
 COPY . /opt/snafu

--- a/snafu/stressng_wrapper/Dockerfile
+++ b/snafu/stressng_wrapper/Dockerfile
@@ -3,12 +3,12 @@ FROM registry.access.redhat.com/ubi8:latest
 # install requirements
 COPY snafu/image_resources/centos8.repo /etc/yum.repos.d/centos8.repo
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-RUN dnf install -y --enablerepo=centos8 --enablerepo=centos8-appstream --enablerepo=epel --nodocs stress-ng python39-pip python39-requests
-RUN dnf install -y --enablerepo=centos8 --enablerepo=centos8-appstream --nodocs procps-ng iproute net-tools ethtool nmap iputils
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm python39 && dnf clean all
+RUN dnf install -y --enablerepo=centos8 --enablerepo=centos8-appstream --enablerepo=epel --nodocs stress-ng python39-requests \
+    procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
 
-RUN dnf clean all
 COPY . /opt/snafu
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/
 RUN ln -s /usr/bin/python3 /usr/bin/python
 

--- a/snafu/sysbench/Dockerfile
+++ b/snafu/sysbench/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Sai Sindhur Malleni <smalleni@redhat.org>
 RUN dnf install -y --nodocs https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 RUN dnf install -y --nodocs sysbench && dnf clean all
 
-RUN dnf install -y --nodocs python3.8 procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
+RUN dnf install -y --nodocs python39 procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
 RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY . /opt/snafu
 RUN pip3 install --upgrade pip # benchmark-wrapper fails to install otherwise

--- a/snafu/trex_wrapper/Dockerfile
+++ b/snafu/trex_wrapper/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8:latest
 
 # install requirements
-RUN dnf -y install --nodocs git wget procps python39 vim python39-pip pciutils && dnf clean all
+RUN dnf -y install --nodocs git wget procps python39 vim pciutils && dnf clean all
 COPY snafu/image_resources/centos8.repo /etc/yum.repos.d/centos8.repo
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN dnf install -y --nodocs hostname iproute net-tools ethtool nmap iputils https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && dnf clean all
@@ -22,8 +22,8 @@ RUN chmod +x /usr/local/bin/run*
 
 # copy snafu script
 RUN ln -s /usr/bin/python3 /usr/bin/python
-RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/
 
 WORKDIR /opt/trex/v2.87

--- a/snafu/trex_wrapper/Dockerfile
+++ b/snafu/trex_wrapper/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8:latest
 
 # install requirements
-RUN dnf -y install --nodocs git wget procps python3 vim python3-pip pciutils && dnf clean all
+RUN dnf -y install --nodocs git wget procps python39 vim python39-pip pciutils && dnf clean all
 COPY snafu/image_resources/centos8.repo /etc/yum.repos.d/centos8.repo
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN dnf install -y --nodocs hostname iproute net-tools ethtool nmap iputils https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && dnf clean all

--- a/snafu/upgrade_openshift_wrapper/Dockerfile
+++ b/snafu/upgrade_openshift_wrapper/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8:latest
 
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs python3 python3-pip  && dnf clean all
+RUN dnf install -y --nodocs python39 python39-pip  && dnf clean all
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz -C /usr/bin/ oc
 RUN ln -s /usr/bin/python3 /usr/bin/python

--- a/snafu/upgrade_openshift_wrapper/Dockerfile
+++ b/snafu/upgrade_openshift_wrapper/Dockerfile
@@ -1,10 +1,10 @@
 FROM registry.access.redhat.com/ubi8:latest
 
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs python39 python39-pip  && dnf clean all
+RUN dnf install -y --nodocs python39  && dnf clean all
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz -C /usr/bin/ oc
 RUN ln -s /usr/bin/python3 /usr/bin/python
-RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/

--- a/snafu/upgrade_openshift_wrapper/Dockerfile.ppc64le
+++ b/snafu/upgrade_openshift_wrapper/Dockerfile.ppc64le
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8:latest
 
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs python3 python3-pip gcc python3-devel gcc-c++ atlas-devel gcc-gfortran && dnf clean all
+RUN dnf install -y --nodocs python39 python39-pip gcc python39-devel gcc-c++ atlas-devel gcc-gfortran && dnf clean all
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz -C /usr/bin/ oc
 RUN ln -s /usr/bin/python3 /usr/bin/python

--- a/snafu/upgrade_openshift_wrapper/Dockerfile.ppc64le
+++ b/snafu/upgrade_openshift_wrapper/Dockerfile.ppc64le
@@ -1,11 +1,11 @@
 FROM registry.access.redhat.com/ubi8:latest
 
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs python39 python39-pip gcc python39-devel gcc-c++ atlas-devel gcc-gfortran && dnf clean all
+RUN dnf install -y --nodocs python39 gcc python39-devel gcc-c++ atlas-devel gcc-gfortran && dnf clean all
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz -C /usr/bin/ oc
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN python3 -m pip install --upgrade cython numpy importlib_metadata 'urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1' && python3 -m pip install --upgrade scipy pandas
-RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/

--- a/snafu/vegeta_wrapper/Dockerfile
+++ b/snafu/vegeta_wrapper/Dockerfile
@@ -1,10 +1,10 @@
 FROM registry.access.redhat.com/ubi8:latest
 
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs python39 python39-pip procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
+RUN dnf install -y --nodocs python39 procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
 RUN curl -L https://github.com/tsenart/vegeta/releases/download/v12.8.3/vegeta-12.8.3-linux-amd64.tar.gz | tar xz -C /usr/bin/ vegeta
 RUN ln -s /usr/bin/python3 /usr/bin/python
-RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/

--- a/snafu/vegeta_wrapper/Dockerfile
+++ b/snafu/vegeta_wrapper/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8:latest
 
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs python3 python3-pip procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
+RUN dnf install -y --nodocs python39 python39-pip procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
 RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
 RUN curl -L https://github.com/tsenart/vegeta/releases/download/v12.8.3/vegeta-12.8.3-linux-amd64.tar.gz | tar xz -C /usr/bin/ vegeta
 RUN ln -s /usr/bin/python3 /usr/bin/python

--- a/snafu/ycsb_wrapper/Dockerfile
+++ b/snafu/ycsb_wrapper/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8:latest
 
 RUN curl -L https://github.com/brianfrankcooper/YCSB/releases/download/0.15.0/ycsb-0.15.0.tar.gz | tar xz && mv ycsb-0.15.0 ycsb
 RUN dnf install -y --nodocs https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-RUN dnf install -y --nodocs git java python39 python2 python39-pip procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
+RUN dnf install -y --nodocs git java python39 python2 procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
 RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY . /opt/snafu/
 RUN pip3 install -e /opt/snafu/

--- a/snafu/ycsb_wrapper/Dockerfile
+++ b/snafu/ycsb_wrapper/Dockerfile
@@ -5,4 +5,5 @@ RUN dnf install -y --nodocs https://dl.fedoraproject.org/pub/epel/epel-release-l
 RUN dnf install -y --nodocs git java python39 python2 procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
 RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY . /opt/snafu/
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/

--- a/snafu/ycsb_wrapper/Dockerfile
+++ b/snafu/ycsb_wrapper/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8:latest
 
 RUN curl -L https://github.com/brianfrankcooper/YCSB/releases/download/0.15.0/ycsb-0.15.0.tar.gz | tar xz && mv ycsb-0.15.0 ycsb
 RUN dnf install -y --nodocs https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-RUN dnf install -y --nodocs git java python3 python2 python3-pip procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
+RUN dnf install -y --nodocs git java python39 python2 python39-pip procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
 RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY . /opt/snafu/
 RUN pip3 install -e /opt/snafu/

--- a/snafu/ycsb_wrapper/Dockerfile.ppc64le
+++ b/snafu/ycsb_wrapper/Dockerfile.ppc64le
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8:latest
 
 RUN curl -L https://github.com/brianfrankcooper/YCSB/releases/download/0.15.0/ycsb-0.15.0.tar.gz | tar xz && mv ycsb-0.15.0 ycsb
 RUN dnf install -y --nodocs https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-RUN dnf install -y --nodocs git java python39 python2 python39-pip procps-ng iproute net-tools ethtool nmap iputils gcc python39-devel gcc-c++ atlas-devel gcc-gfortran && dnf clean all
+RUN dnf install -y --nodocs git java python39 python2 procps-ng iproute net-tools ethtool nmap iputils gcc python39-devel gcc-c++ atlas-devel gcc-gfortran && dnf clean all
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN python3 -m pip install --upgrade cython numpy importlib_metadata 'urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1' && python3 -m pip install --upgrade scipy pandas
 COPY . /opt/snafu/

--- a/snafu/ycsb_wrapper/Dockerfile.ppc64le
+++ b/snafu/ycsb_wrapper/Dockerfile.ppc64le
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8:latest
 
 RUN curl -L https://github.com/brianfrankcooper/YCSB/releases/download/0.15.0/ycsb-0.15.0.tar.gz | tar xz && mv ycsb-0.15.0 ycsb
 RUN dnf install -y --nodocs https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-RUN dnf install -y --nodocs git java python3 python2 python3-pip procps-ng iproute net-tools ethtool nmap iputils gcc python3-devel gcc-c++ atlas-devel gcc-gfortran && dnf clean all
+RUN dnf install -y --nodocs git java python39 python2 python39-pip procps-ng iproute net-tools ethtool nmap iputils gcc python39-devel gcc-c++ atlas-devel gcc-gfortran && dnf clean all
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN python3 -m pip install --upgrade cython numpy importlib_metadata 'urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1' && python3 -m pip install --upgrade scipy pandas
 COPY . /opt/snafu/


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Most of builds for arm64 amd amd64 archs have been fixed. Some findings of the failed ones:
- We're unable to build oslat container since the packages rt-tests and dumb-init are not longer available in the repos. cc: @smalleni 
- Cyclitest build fails due to broken link to the rt-tests RPM, in addition, we should avoid using static links as builds won't work for multiarch builds. cc @smalleni 
- Hammerdb for arm64 fails due to there's no offial odbc driver for arm64. cc @mkarg75

### Fixes
