### PR TITLE
add host/pod to ES doc for analysis

### DIFF
--- a/snafu/fs_drift_wrapper/trigger_fs_drift.py
+++ b/snafu/fs_drift_wrapper/trigger_fs_drift.py
@@ -1,9 +1,9 @@
 import json
 import os
 import re
+import socket
 import subprocess
 import time
-import socket
 
 from snafu.vfs_stat import get_vfs_stat_dict
 

--- a/snafu/fs_drift_wrapper/trigger_fs_drift.py
+++ b/snafu/fs_drift_wrapper/trigger_fs_drift.py
@@ -3,6 +3,7 @@ import os
 import re
 import subprocess
 import time
+import socket
 
 from snafu.vfs_stat import get_vfs_stat_dict
 
@@ -28,6 +29,8 @@ class _trigger_fs_drift:
         self.uuid = uuid
         self.sample = sample
         self.cluster_name = cluster_name
+        # for K8S this is really a pod ID, not a host
+        self.host = socket.gethostname()
 
     def ensure_dir_exists(self, directory):
         if not os.path.exists(directory):
@@ -81,6 +84,7 @@ class _trigger_fs_drift:
                 thrd["fsdict"] = fsdict
                 thrd["date"] = timestamp
                 thrd["thr-id"] = tid
+                thrd["host"] = self.host
                 thrd["sample"] = self.sample
                 thrd["cluster_name"] = self.cluster_name
                 thrd["uuid"] = self.uuid


### PR DESCRIPTION
this is a trivial change to the fs-drift wrapper in support of fs-drift analysis code to be added in a separate PR 
