### PR TITLE
Change pre-commit and version workflow to run monthly

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -5,7 +5,7 @@ on:
     paths:
       - 'setup.cfg'
   schedule:
-    - cron: '0 0 * * 1'
+    - cron: '0 0 1 * *'
 jobs:
   update_requirements:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,6 @@ ci:
         for more information, see https://pre-commit.ci
     autofix_prs: false
     autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
-    autoupdate_schedule: weekly
+    autoupdate_schedule: monthly
     skip: []
     submodules: false


### PR DESCRIPTION
### Description

Once a week we get the possibility of two PRs opening up: pre-commit auto-update and requirements auto-update. I thought it would be useful to do these upgrades once a week when I created the initial configuration, however now I'm realizing it's a lot of work that could be trimmed down. We don't need to stay super up-to-date on these requirements, as its not required for running snafu, so might be better to wait to do these upgrades every now and then so we can reduce notification fatigue.

### Fixes

Changes pre-commit auto-updates and requirements auto-updates to run monthly, rather than weekly.