### PR TITLE
Update OpenShift Scale to use timeout variable and add additional scale check

### DIFF
--- a/snafu/scale_openshift_wrapper/trigger_scale.py
+++ b/snafu/scale_openshift_wrapper/trigger_scale.py
@@ -297,10 +297,10 @@ class Trigger_scale:
         # If we don't do this it will auto-complete a scale-down even though the workers
         # have not been eliminated yet
         new_worker_list = nodes.get(
-                    label_selector="node-role.kubernetes.io/worker,"
-                    "!node-role.kubernetes.io/master,"
-                    "!node-role.kubernetes.io/infra,"
-                    "!node-role.kubernetes.io/workload"
+            label_selector="node-role.kubernetes.io/worker,"
+            "!node-role.kubernetes.io/master,"
+            "!node-role.kubernetes.io/infra,"
+            "!node-role.kubernetes.io/workload"
         ).attributes.items
         for i in range(len(new_worker_list)):
             while i < len(new_worker_list) and new_worker_list[i].spec.unschedulable:
@@ -322,23 +322,25 @@ class Trigger_scale:
         logger.info("All workers schedulable")
 
         logger.inf("Verifying correct worker count")
-        current_workers = len(nodes.get(
-                    label_selector="node-role.kubernetes.io/worker,"
-                    "!node-role.kubernetes.io/master,"
-                    "!node-role.kubernetes.io/infra,"
-                    "!node-role.kubernetes.io/workload"
-        ).attributes.items)
+        current_workers = len(
+            nodes.get(
+                label_selector="node-role.kubernetes.io/worker,"
+                "!node-role.kubernetes.io/master,"
+                "!node-role.kubernetes.io/infra,"
+                "!node-role.kubernetes.io/workload"
+            ).attributes.items
+        )
         while current_workers != int(self.scale):
-                current_time = time.time()
-                if current_time >= end_time:
-                    logger.error("Timeout %d minutes exceeded" % self.timeout)
-                    exit(1)
+            current_time = time.time()
+            if current_time >= end_time:
+                logger.error("Timeout %d minutes exceeded" % self.timeout)
+                exit(1)
 
-                logger.debug(
-                    "Number of ready workers: %d. Waiting %d seconds for next check..."
-                    % (len(new_worker_list), self.poll_interval)
-                )
-                time.sleep(self.poll_interval)
+            logger.debug(
+                "Number of ready workers: %d. Waiting %d seconds for next check..."
+                % (len(new_worker_list), self.poll_interval)
+            )
+            time.sleep(self.poll_interval)
 
         logger.info("Correct worker count verified")
 


### PR DESCRIPTION
### Description

Updating the OpenShift scale workload to actually utilize the timeout variable it was able to take as well as add an additional check before completion that we are at the correct scale size.

### Fixes
