### PR TITLE
fix sysbench arm64 build

### DIFF
--- a/snafu/sysbench/Dockerfile
+++ b/snafu/sysbench/Dockerfile
@@ -1,11 +1,11 @@
 FROM registry.access.redhat.com/ubi8:latest
-MAINTAINER Sai Sindhur Malleni <smalleni@redhat.org>
+MAINTAINER Ed Chong <edchong@redhat.com>
 
 RUN dnf install -y --nodocs https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 RUN dnf install -y --nodocs sysbench && dnf clean all
 
-RUN dnf install -y --nodocs python3.8 procps-ng iproute net-tools ethtool nmap iputils && dnf clean all
+RUN dnf install -y --nodocs python3.8 python38-devel procps-ng iproute net-tools ethtool nmap iputils gcc && dnf clean all
 RUN ln -s /usr/bin/python3 /usr/bin/python
-COPY . /opt/snafu
 RUN pip3 install --upgrade pip # benchmark-wrapper fails to install otherwise
-RUN pip3 install -e /opt/snafu/
+COPY . /opt/snafu
+RUN pip3 install -r /opt/snafu/requirements/py38-reqs/install.txt -e /opt/snafu


### PR DESCRIPTION
### Description
`arm64`'s container build was failing

### Fixes
Missing `gcc` and `python38-devel` was causing benchmark-wrapper not to install