### PR TITLE
Adding pip upgrade and missing dependencies for test without CI tests

### DIFF
--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -76,7 +76,9 @@ wait_clean
 for dir in ${test_list}; do
   start_time=`date`
   figlet "CI test for ${dir}"
-  if $dir/ci_test.sh; then
+  if [ ! -f $dir/ci_test.sh ]; then
+    result="No CI test"
+  elif $dir/ci_test.sh; then
     result="PASS"
   else
     result="FAIL"

--- a/snafu/cyclictest_wrapper/Dockerfile
+++ b/snafu/cyclictest_wrapper/Dockerfile
@@ -1,11 +1,12 @@
 FROM registry.centos.org/centos:8
 USER root
 RUN dnf install -y --nodocs python3 python3-pip python3-devel numactl-devel perl \
-    epel-release procps-ng iproute net-tools ethtool nmap iputils
-RUN dnf -y install https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/rt-tests-1.9-2.el8.x86_64.rpm
+    epel-release procps-ng iproute net-tools ethtool nmap iputils gcc
+RUN dnf -y install https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/rt-tests-1.10-3.el8.x86_64.rpm
 RUN dnf -y --enablerepo=extras install --nodocs wget tmux stress-ng \
     https://cbs.centos.org/kojifiles/packages/dumb-init/1.2.2/6.el8/x86_64/dumb-init-1.2.2-6.el8.x86_64.rpm \
     && dnf clean all && rm -rf /var/cache/yum
 COPY . /opt/snafu
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/
 RUN ln -s /usr/bin/python3 /usr/bin/python

--- a/snafu/dns_perf_wrapper/Dockerfile
+++ b/snafu/dns_perf_wrapper/Dockerfile
@@ -1,11 +1,12 @@
 FROM registry.centos.org/centos:8
 
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y epel-release && dnf install -y --nodocs redis python3 python3-pip openssl-devel ck-devel yum-plugin-copr && \
+RUN dnf install -y epel-release && dnf install -y --nodocs redis python3 python3-pip openssl-devel ck-devel yum-plugin-copr gcc && \
     dnf copr enable @dnsoarc/dnsperf -y && \
     dnf install dnsperf -y && \
     dnf clean all && rm -rf /var/cache/yum
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz -C /usr/bin/ oc && ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/

--- a/snafu/linpack_wrapper/Dockerfile
+++ b/snafu/linpack_wrapper/Dockerfile
@@ -1,10 +1,11 @@
 FROM registry.access.redhat.com/ubi8:latest
 
-RUN dnf install -y --nodocs python3-pip
+RUN dnf install -y --nodocs python3-pip python3-devel gcc
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/
 
-RUN curl https://software.intel.com/content/dam/develop/external/us/en/documents/l_onemklbench_p_2021.2.0_109.tgz --output linpack.tgz
+RUN curl -L https://software.intel.com/content/dam/develop/external/us/en/documents/l_onemklbench_p_2021.2.0_109.tgz --output linpack.tgz
 RUN tar xzvf linpack.tgz -C /opt

--- a/snafu/oslat_wrapper/Dockerfile
+++ b/snafu/oslat_wrapper/Dockerfile
@@ -1,11 +1,12 @@
 FROM registry.centos.org/centos:8
 USER root
 RUN dnf install -y --nodocs python3 python3-pip python3-devel numactl-devel perl \
-    epel-release procps-ng iproute net-tools ethtool nmap iputils
-RUN dnf -y install -y https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/rt-tests-1.9-2.el8.x86_64.rpm
+    epel-release procps-ng iproute net-tools ethtool nmap iputils gcc
+RUN dnf -y install -y https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/rt-tests-1.10-3.el8.x86_64.rpm
 RUN dnf -y --enablerepo=extras install --nodocs wget tmux \
     https://cbs.centos.org/kojifiles/packages/dumb-init/1.2.2/6.el8/x86_64/dumb-init-1.2.2-6.el8.x86_64.rpm \
     && dnf clean all && rm -rf /var/cache/yum
 COPY . /opt/snafu
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/
 RUN ln -s /usr/bin/python3 /usr/bin/python

--- a/snafu/trex_wrapper/Dockerfile
+++ b/snafu/trex_wrapper/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8:latest
 
 # install requirements
-RUN dnf -y install --nodocs git wget procps python3 vim python3-pip pciutils && dnf clean all
+RUN dnf -y install --nodocs git wget procps python3 vim python3-pip python3-devel pciutils gcc && dnf clean all
 COPY snafu/image_resources/centos8.repo /etc/yum.repos.d/centos8.repo
 COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN dnf install -y --nodocs hostname iproute net-tools ethtool nmap iputils https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && dnf clean all
@@ -24,6 +24,7 @@ RUN chmod +x /usr/local/bin/run*
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir -p /opt/snafu/
 COPY . /opt/snafu/
+RUN pip3 install --upgrade pip
 RUN pip3 install -e /opt/snafu/
 
 WORKDIR /opt/trex/v2.87


### PR DESCRIPTION
Signed-off-by: Vicente Zepeda Mas <vzepedam@redhat.com>

### Description

Adding pip upgrade to Dockerfiles and missing dependencies due to build failures.

Modified script to skip over benchmarks with no test file, this fixes failing tests on:

- cyclictest
- dns_perf
- linpack
- oslat
- trex



### Fixes
