### PR TITLE
Assume sysbench is in path

### DIFF
--- a/snafu/sysbench/trigger_sysbench.py
+++ b/snafu/sysbench/trigger_sysbench.py
@@ -43,7 +43,7 @@ class trigger_sysbench:
         #  open config file
         config_file = open(self.sysbench_file, "r")
 
-        cmd = "/usr/bin/sysbench"
+        cmd = "sysbench"
         #  for each option add it to the command line
         for option in config_file:
             option = option.strip()


### PR DESCRIPTION
Original implementation had sysbench hardcoded to a path
which breaks on different distros.