### PR TITLE
Add centos-stream repos, and point centos repos to vault.centos.org.

### DIFF
--- a/snafu/hammerdb/Dockerfile
+++ b/snafu/hammerdb/Dockerfile
@@ -1,14 +1,14 @@
 FROM registry.access.redhat.com/ubi8:latest
 
 # install requirements
-COPY snafu/image_resources/centos8.repo /etc/yum.repos.d/centos8.repo
-COPY snafu/image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --enablerepo=centos8 --enablerepo=centos8-appstream --nodocs tcl unixODBC python3-pip python3-requests python3-devel gcc
-RUN dnf install -y --enablerepo=centos8 --enablerepo=centos8-appstream --nodocs procps-ng iproute net-tools ethtool nmap iputils
-RUN dnf -y install --enablerepo=centos8 --enablerepo=centos8-appstream --nodocs mysql-libs mysql-common mysql-devel mysql-errmsg libpq
+COPY snafu/image_resources/centos8-stream.repo /etc/yum.repos.d/centos8-stream.repo
+COPY snafu/image_resources/centos8-stream-appstream.repo /etc/yum.repos.d/centos8-stream-appstream.repo
+RUN dnf install -y --enablerepo=centos-stream-8 --enablerepo=centos-stream-8-appstream --nodocs tcl unixODBC python3-pip python3-requests python3-devel gcc
+RUN dnf install -y --enablerepo=centos-stream-8 --enablerepo=centos-stream-8-appstream --nodocs procps-ng iproute net-tools ethtool nmap iputils
+RUN dnf -y install --enablerepo=centos-stream-8 --enablerepo=centos-stream-8-appstream --nodocs mysql-libs mysql-common mysql-devel mysql-errmsg libpq
 
 RUN curl https://packages.microsoft.com/config/rhel/8/prod.repo -o /etc/yum.repos.d/mssql-release.repo
-RUN ACCEPT_EULA=Y dnf -y install --skip-broken --enablerepo=centos8 --enablerepo=centos8-appstream --nodocs msodbcsql17
+RUN ACCEPT_EULA=Y dnf -y install --skip-broken --enablerepo=centos-stream-8 --enablerepo=centos-stream-8-appstream --nodocs msodbcsql17
 RUN dnf clean all
 COPY . /opt/snafu
 RUN pip3 install --upgrade pip

--- a/snafu/image_resources/centos8-appstream.repo
+++ b/snafu/image_resources/centos8-appstream.repo
@@ -1,5 +1,5 @@
 [centos8-appstream]
 name=CentOS-8-Appstream
-baseurl=http://mirror.centos.org/centos/8/AppStream/$basearch/os/
+baseurl=http://vault.centos.org/centos/8/AppStream/$basearch/os/
 enabled=0
 gpgcheck=0

--- a/snafu/image_resources/centos8-stream-appstream.repo
+++ b/snafu/image_resources/centos8-stream-appstream.repo
@@ -1,0 +1,5 @@
+[centos-stream-8-appstream]
+name=CentOS-stream-8-Appstream
+baseurl=http://mirror.centos.org/centos/8-stream/AppStream/$basearch/os/
+enabled=0
+gpgcheck=0

--- a/snafu/image_resources/centos8-stream.repo
+++ b/snafu/image_resources/centos8-stream.repo
@@ -1,0 +1,5 @@
+[centos-stream-8]
+name=CentOS-Stream-8
+baseurl=http://mirror.centos.org/centos/8-stream//BaseOS/$basearch/os/
+enabled=0
+gpgcheck=0

--- a/snafu/image_resources/centos8.repo
+++ b/snafu/image_resources/centos8.repo
@@ -1,5 +1,5 @@
 [centos8]
 name=CentOS-8
-baseurl=http://mirror.centos.org/centos/8/BaseOS/$basearch/os/
+baseurl=http://vault.centos.org/centos/8/BaseOS/$basearch/os/
 enabled=0
 gpgcheck=0


### PR DESCRIPTION
This PR adds 2 repos for centos stream 8, and switches hammerdb to use them. 

It also "fixes" the existing centos8 repos. They currently point to a URL that has been deprecated. Switched to vault.centos.org.