### PR TITLE
Update for centos 8-stream

### DIFF
--- a/snafu/image_resources/centos8-appstream.repo
+++ b/snafu/image_resources/centos8-appstream.repo
@@ -1,5 +1,5 @@
 [centos8-appstream]
 name=CentOS-8-Appstream
-baseurl=http://mirror.centos.org/centos/8/AppStream/$basearch/os/
+baseurl=http://mirror.centos.org/centos/8-stream/AppStream/$basearch/os/
 enabled=0
 gpgcheck=0

--- a/snafu/image_resources/centos8.repo
+++ b/snafu/image_resources/centos8.repo
@@ -1,5 +1,5 @@
 [centos8]
 name=CentOS-8
-baseurl=http://mirror.centos.org/centos/8/BaseOS/$basearch/os/
+baseurl=http://mirror.centos.org/centos/8-stream/BaseOS/$basearch/os/
 enabled=0
 gpgcheck=0


### PR DESCRIPTION
### Description

Centos 8 repo is no longer valid. 8-stream is its replacement.

### Fixes
https://github.com/cloud-bulldozer/benchmark-wrapper/issues/416