### PR TITLE
Change git:// links to https:// in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 ---
 repos:
-  - repo: git://github.com/Lucas-C/pre-commit-hooks
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.10
     hooks:
       - id: remove-tabs
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
     hooks:
       - id: trailing-whitespace


### PR DESCRIPTION
### Description

Replace `git://` links with `https://` links in pre-commit configuration. The git protocol was phased out; more information can be found here: https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git

### Fixes

pre-commit CI issues faced in #414 