### PR TITLE
Index uperf timestamp field

### DIFF
--- a/snafu/benchmarks/uperf/uperf.py
+++ b/snafu/benchmarks/uperf/uperf.py
@@ -292,6 +292,7 @@ class Uperf(Benchmark):
 
                 datapoint = UperfStat(
                     uperf_ts=datetime.datetime.fromtimestamp(int(timestamp) / 1000).isoformat(),
+                    timestamp=datetime.datetime.fromtimestamp(int(timestamp) / 1000).isoformat(),
                     bytes=num_bytes,
                     norm_byte=num_bytes - prev_bytes,
                     ops=ops,


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

For historical reasons I unknown, we're sending the uperf timestamp in a field called uperf_ts rather than timestamp like every other tests. Let's send add this timestamp field and keep the uperf_ts one for now to maintain compatibility .