### PR TITLE
Add timestamp field to dataclass

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
     hooks:
       - id: black
         args: ['--line-length', '110']
+        additional_dependencies: ['click==8.0.4']
 
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1

--- a/snafu/benchmarks/uperf/uperf.py
+++ b/snafu/benchmarks/uperf/uperf.py
@@ -99,6 +99,7 @@ class UperfStat:
     """Parsed Uperf Statistic."""
 
     uperf_ts: str
+    timestamp: str
     bytes: int
     norm_byte: int
     ops: int


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

### Fixes

```
2022-04-07T21:36:16Z - WARNING  - MainProcess - uperf: The following params will be overwritten due to values found in workload profile name: test_type, protocol, num_threads
Traceback (most recent call last):
  File "/usr/local/bin/run_snafu", line 33, in <module>
    sys.exit(load_entry_point('snafu', 'console_scripts', 'run_snafu')())
  File "/opt/snafu/snafu/run_snafu.py", line 142, in main
    es, process_generator(index_args, parser), parallel_setting
  File "/opt/snafu/snafu/utils/py_es_bulk.py", line 172, in streaming_bulk
    for ok, resp_payload in streaming_bulk_generator:
  File "/usr/local/lib/python3.6/site-packages/elasticsearch/helpers/actions.py", line 320, in streaming_bulk
    actions, chunk_size, max_chunk_bytes, client.transport.serializer
  File "/usr/local/lib/python3.6/site-packages/elasticsearch/helpers/actions.py", line 155, in _chunk_actions
    for action, data in actions:
  File "/opt/snafu/snafu/utils/py_es_bulk.py", line 118, in actions_tracking_closure
    for cl_action in cl_actions:
  File "/opt/snafu/snafu/run_snafu.py", line 189, in process_generator
    for result in wrapper_object.run():
  File "/opt/snafu/snafu/benchmarks/_benchmark.py", line 162, in run
    yield from self.collect()
  File "/opt/snafu/snafu/benchmarks/uperf/uperf.py", line 359, in collect
    result_data: List[UperfStat] = self.get_results_from_stdout(stdout)
  File "/opt/snafu/snafu/benchmarks/uperf/uperf.py", line 300, in get_results_from_stdout
    norm_ltcy=norm_ltcy,
TypeError: __init__() got an unexpected keyword argument 'timestamp'
```
