### PR TITLE
Assign uperf server port as an option

### DIFF
--- a/snafu/benchmarks/uperf/uperf.py
+++ b/snafu/benchmarks/uperf/uperf.py
@@ -68,6 +68,7 @@ class UperfConfig:
     client_ips: Optional[str] = None
     service_ip: Optional[str] = None
     service_type: Optional[str] = None
+    port: Optional[str] = None
     client_node: Optional[str] = None
     server_node: Optional[str] = None
     num_pairs: Optional[str] = None
@@ -144,6 +145,7 @@ class Uperf(Benchmark):
         ConfigArgument("--hostnet", dest="hostnetwork", env_var="hostnet", default="False"),
         ConfigArgument("--serviceip", dest="service_ip", env_var="serviceip", default="False"),
         ConfigArgument("--servicetype", dest="service_type", env_var="servicetype", default=""),
+        ConfigArgument("--port", dest="port", env_var="port", default="30000"),
         ConfigArgument("--server-node", dest="server_node", env_var="server_node", default=""),
         ConfigArgument("--client-node", dest="client_node", env_var="client_node", default=""),
         ConfigArgument("--num-pairs", dest="num_pairs", env_var="num_pairs", default=""),
@@ -328,7 +330,7 @@ class Uperf(Benchmark):
         Returns immediately if a sample fails. Will attempt to Uperf run three times for each sample.
         """
 
-        cmd = shlex.split(f"uperf -v -a -R -i 1 -m {self.config.workload} -P 30000")
+        cmd = shlex.split(f"uperf -v -a -R -i 1 -m {self.config.workload} -P {self.config.port}")
         _plural = "s" if self.config.sample > 1 else ""
         self.logger.info(f"Collecting {self.config.sample} sample{_plural} of Uperf")
 


### PR DESCRIPTION
Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

### Description
This is needed for fixing an issue with running
multiple pairs using NodePort.

Related PR: https://github.com/cloud-bulldozer/benchmark-operator/pull/755
