### PR TITLE
Add Prometheus Metric recording to PGBench

### DIFF
--- a/snafu/pgbench_wrapper/trigger_pgbench.py
+++ b/snafu/pgbench_wrapper/trigger_pgbench.py
@@ -171,13 +171,16 @@ class Trigger_pgbench:
         print("+{}+".format("-" * (115)))
 
     def emit_actions(self):
+        sample_starttime = datetime.utcnow().strftime("%s")
         output = self._run_pgbench()
         if output[2] == 1:
             print("PGBench failed to execute, trying one more time..")
+            sample_starttime = datetime.utcnow().strftime("%s")
             output = self._run_pgbench()
             if output[2] == 1:
                 print("PGBench failed to execute a second time, stopping...")
                 exit(1)
+        sample_endtime = datetime.utcnow().strftime("%s")
         data = self._parse_stdout(output[0])
         progress = self._parse_stderr(output[1])
         documents = self._json_payload(self.meta_processed, data)
@@ -200,3 +203,15 @@ class Trigger_pgbench:
         if len(documents_prog) > 0:
             for document in documents_prog:
                 yield document, "results"
+        sample_info_dict = {
+            "uuid": self.uuid,
+            "user": self.user,
+            "cluster_name": self.cluster_name,
+            "starttime": sample_starttime,
+            "endtime": sample_endtime,
+            "sample": self.run[0],
+            "tool": "pgbench",
+            "test_config": self.meta_processed[0],
+        }
+
+        yield sample_info_dict, "get_prometheus_trigger"


### PR DESCRIPTION
### Description

This PR adds the ability for PGBench to record prometheus metrics to a specified elasticsearch server once a sample has finished.