### PR TITLE
Added exit status for uperf failures

### DIFF
--- a/snafu/benchmarks/uperf/uperf.py
+++ b/snafu/benchmarks/uperf/uperf.py
@@ -4,6 +4,7 @@
 import dataclasses
 import datetime
 import re
+import sys
 import shlex
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
@@ -346,14 +347,14 @@ class Uperf(Benchmark):
         for sample_num, sample in enumerate(samples):
             if not sample.success:
                 self.logger.critical(f"Uperf failed to run! Got results: {sample}")
-                return
+                sys.exit(1)
 
             self.logger.info(f"Finished collecting sample {sample_num}")
             self.logger.debug(f"Got sample: {sample}")
 
             if sample.successful.stdout is None:
                 self.logger.critical(f"Uperf ran successfully, but didn't get stdout. Got results: {sample}")
-                return
+                sys.exit(1)
 
             # Only show the full output if debug is enabled
             self.logger.debug(sample.successful.stdout)


### PR DESCRIPTION
### Description
Context: https://github.com/cloud-bulldozer/benchmark-operator/issues/773
Realted operator PR: https://github.com/cloud-bulldozer/benchmark-operator/pull/782
Adding exit status for uperf failure cases. This change needs to be integrated in all the workloads that use sanfu for execution as a future action item.

### Fixes
Made code changes to return a non-zero exit in case of failures.

### Testing
Tested it integrating with benchmark-operator.

### Screenshots
 - <a href="https://drive.google.com/file/d/1BfU_-9pjQqJnyWILQ2YTmG1abLrNciaN/view?usp=sharing"><img src="https://drive.google.com/file/d/1BfU_-9pjQqJnyWILQ2YTmG1abLrNciaN/view?usp=sharing" style="width: 500px; max-width: 100%; height: auto" title="success case" /></a>
 - <a href="https://drive.google.com/file/d/1EfReFELZbmhhLQNtn2FSfyMCkq5B1rBM/view?usp=sharing"><img src="https://drive.google.com/file/d/1EfReFELZbmhhLQNtn2FSfyMCkq5B1rBM/view?usp=sharing" style="width: 500px; max-width: 100%; height: auto" title="failure case" /></a>
