### PR TITLE
fix: coremark-pro flag

### DIFF
--- a/snafu/benchmarks/coremarkpro/coremarkpro.py
+++ b/snafu/benchmarks/coremarkpro/coremarkpro.py
@@ -38,7 +38,7 @@ class Coremarkpro(Benchmark):
             required=False,
         ),
         ConfigArgument(
-            "-worker",
+            "-w",
             "--worker",
             help="CoreMark Pro's worker",
             dest="worker",


### PR DESCRIPTION
### Description

Bug where the single character flag was `-worker` instead of `-w` for CoreMark-Pro

