### PR TITLE
Allow messages received to be more than sent

### DIFF
--- a/snafu/log_generator_wrapper/trigger_log_generator.py
+++ b/snafu/log_generator_wrapper/trigger_log_generator.py
@@ -283,7 +283,7 @@ class Trigger_log_generator:
                     messages_received = self._check_es(int(start_time), int(end_time))
                 elif self.kafka_bootstrap_server:
                     messages_received = self._check_kafka(start_time, end_time + self.timeout)
-                if messages_received == message_count:
+                if messages_received >= message_count:
                     received_all_messages = True
                 else:
                     logger.info("Message check failed. Retrying until timeout")


### PR DESCRIPTION
I have seen this kind of results a few times when running the logging test:

| Messages Sent | Expected Messages | Messages Received
| --- | --- | --- |
| 10800000 | 10800000 | 10800019
| 360000 | 360000 | 360059

This is making the test going to the timeout and setting to false the result.

This can be fixed comparing with >= instead of ==





